### PR TITLE
Sanitize the incoming tenant

### DIFF
--- a/src/__tests__/sanitize.test.ts
+++ b/src/__tests__/sanitize.test.ts
@@ -1,27 +1,27 @@
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import { sanitizeTests } from '../sanitize';
+import { sanitizeTenant } from '../sanitize';
 
 configure({ adapter: new Adapter() });
 
 describe('sanitize', () => {
   it('Handles correct tenants', () => {
-    expect(sanitizeTests('abc')).toEqual('abc');
+    expect(sanitizeTenant('abc')).toEqual('abc');
   });
 
   it('Handles uppercase tenants', () => {
-    expect(sanitizeTests('ABC')).toEqual('abc');
+    expect(sanitizeTenant('ABC')).toEqual('abc');
   });
 
   it('Handles tenants with numbers', () => {
-    expect(sanitizeTests('abc123')).toEqual('abc123');
+    expect(sanitizeTenant('abc123')).toEqual('abc123');
   });
 
   it('Handles tenants with special characters', () => {
-    expect(sanitizeTests('a b c')).toEqual('abc');
-    expect(sanitizeTests('a B c')).toEqual('abc');
-    expect(sanitizeTests('a_b_c')).toEqual('abc');
-    expect(sanitizeTests('a1b2c3')).toEqual('a1b2c3');
-    expect(sanitizeTests('Cognite AS')).toEqual('cogniteas');
+    expect(sanitizeTenant('a b c')).toEqual('abc');
+    expect(sanitizeTenant('a B c')).toEqual('abc');
+    expect(sanitizeTenant('a_b_c')).toEqual('abc');
+    expect(sanitizeTenant('a1b2c3')).toEqual('a1b2c3');
+    expect(sanitizeTenant('Cognite AS')).toEqual('cogniteas');
   });
 });

--- a/src/components/TenantSelector/TenantSelector.tsx
+++ b/src/components/TenantSelector/TenantSelector.tsx
@@ -1,7 +1,7 @@
 import { Button, Form, Input, Spin } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
-import { sanitizeTests } from 'sanitize';
+import { sanitizeTenant } from 'sanitize';
 
 enum TenantValidity {
   CHECKING = 0,
@@ -44,7 +44,7 @@ class TenantSelector extends React.Component<
   constructor(props: TenantSelectorProps) {
     super(props);
     this.state = {
-      tenant: props.initialTenant || '',
+      tenant: sanitizeTenant(props.initialTenant || ''),
       validity: TenantValidity.UNKNOWN,
     };
   }
@@ -104,7 +104,7 @@ class TenantSelector extends React.Component<
 
   private onTenantChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.setState({
-      tenant: sanitizeTests(e.target.value),
+      tenant: sanitizeTenant(e.target.value),
       validity: TenantValidity.UNKNOWN,
     });
   };

--- a/src/sanitize.ts
+++ b/src/sanitize.ts
@@ -5,7 +5,7 @@
  *
  * @return the sanitized CDP project name
  */
-export const sanitizeTests = (input: string): string =>
+export const sanitizeTenant = (input: string): string =>
   input
     // CDP projects cannot have upper-case characters
     .toLowerCase()


### PR DESCRIPTION
Cognite project names are always [a-z0-9_-]+, so ensure that whenever
the state is updated, the new value matches this pattern.

Additionally, rename the helper function because sanitizeTests doesn't
make sense to me.

Fixes #48