### PR TITLE
Add documentation for documentTypeField

### DIFF
--- a/src/interfaces/DocumentTypes.ts
+++ b/src/interfaces/DocumentTypes.ts
@@ -45,6 +45,14 @@ export interface MetaDocProps {
   categoryPriorityList?: string[];
   unknownCategoryName?: string;
   documentTitleField?: string;
+
+  /**
+   * The {@code metadata} field used to group documents into types. If this is
+   * not specified, then {@code doc_type} field will be attempted. If no
+   * {@code doc_type} field is present in the metadata, then the filename will
+   * be attempted to be parsed using the NORSOK standard. If this fails, then
+   * the document will be in the "unknown" group.
+   */
   documentTypeField?: string;
   docTypes?: JsonDocTypes;
   noDocumentsSign?: string;


### PR DESCRIPTION
This has a confusing fallback order; document the property so that
outside users don't have to trace the source code to figure out what
values are supposed to mean, and what happens if this isn't set.

Resolves #124