### PR TITLE
AssetMeta - Change documents ordering

### DIFF
--- a/src/components/AssetMeta/components/DocumentTable.test.tsx
+++ b/src/components/AssetMeta/components/DocumentTable.test.tsx
@@ -6,6 +6,7 @@ import {
   DOCUMENT_WITH_CUSTOM_TYPE_FIELD,
   DOCUMENT_WITHOUT_METADATA,
   DOCUMENT_WITHOUT_TYPE,
+  DOCUMENTS,
   generateDocumentWithDocType,
 } from '../../../mocks';
 import { DocumentTable } from './DocumentTable';
@@ -14,6 +15,7 @@ configure({ adapter: new Adapter() });
 
 const ANT_COLLAPSE_HEADER = '.ant-collapse-header';
 
+// tslint:disable:no-big-function
 describe('DocumentTable', () => {
   it('Renders without exploding', () => {
     const wrapper = mount(<DocumentTable docs={[]} />);
@@ -205,5 +207,20 @@ describe('DocumentTable', () => {
       .hostNodes()
       .simulate('click');
     expect(handleCategoryClick.mock.calls[0][0]).toEqual(['XB']);
+  });
+
+  it('Should sort categories with custom sort', () => {
+    const customCategorySort = (a: string, b: string) =>
+      a > b ? 1 : a < b ? -1 : 0;
+    const wrapper = mount(
+      <DocumentTable docs={DOCUMENTS} customCategorySort={customCategorySort} />
+    );
+    const categories = wrapper
+      .find(ANT_COLLAPSE_HEADER)
+      .hostNodes()
+      .map(node => node.text());
+    for (let i = 0; i < categories.length - 1; i++) {
+      expect(customCategorySort(categories[i], categories[i + 1])).not.toBe(1);
+    }
   });
 });

--- a/src/components/AssetMeta/components/DocumentTable.test.tsx
+++ b/src/components/AssetMeta/components/DocumentTable.test.tsx
@@ -211,9 +211,13 @@ describe('DocumentTable', () => {
 
   it('Should sort categories with custom sort', () => {
     const customCategorySort = (a: string, b: string) =>
-      a > b ? 1 : a < b ? -1 : 0;
+      a > b ? -1 : a < b ? 1 : 0;
     const wrapper = mount(
-      <DocumentTable docs={DOCUMENTS} customCategorySort={customCategorySort} />
+      <DocumentTable
+        docs={DOCUMENTS}
+        categoryPriorityList={[]}
+        customCategorySort={customCategorySort}
+      />
     );
     const categories = wrapper
       .find(ANT_COLLAPSE_HEADER)

--- a/src/components/AssetMeta/components/DocumentTable.tsx
+++ b/src/components/AssetMeta/components/DocumentTable.tsx
@@ -21,6 +21,7 @@ export class DocumentTable extends React.PureComponent<
 > {
   static defaultProps = {
     handleDocumentClick: () => null,
+    categoryPriorityList: ['XB', 'XL'], // categories "P&ID" and "Logic Diagrams" are prioritized by default
   };
 
   renderDocument = (category: string, description: string) => (
@@ -72,12 +73,12 @@ export class DocumentTable extends React.PureComponent<
       docTypes,
       documentTypeField
     );
-    const categoryByPriority = getCategoryByPriority(
+    const { categories, prioritizedCount } = getCategoryByPriority(
       documentsByCategory,
       categoryPriorityList
     );
 
-    if (!categoryByPriority.length) {
+    if (!categories.length) {
       return (
         <NoDocuments data-test-id="no-documents">{`${
           noDocumentsSign
@@ -91,13 +92,20 @@ export class DocumentTable extends React.PureComponent<
       <>
         <TableWrapper>
           <CollapseContainer {...collapseProps}>
-            {categoryByPriority.map(category => {
+            {categories.map((category, i) => {
               const { description, documents } = documentsByCategory[category];
               const header = `${getShortDescription(description)} (${
                 documents.length
               })`;
               return (
-                <PanelWrapper header={header} key={category}>
+                <PanelWrapper
+                  header={header}
+                  key={category}
+                  delimiter={
+                    prioritizedCount === i + 1 &&
+                    prioritizedCount !== categories.length
+                  }
+                >
                   {documents.map(this.renderDocument(category, description))}
                 </PanelWrapper>
               );
@@ -132,8 +140,10 @@ const TextContainerTop = styled.div`
   text-transform: uppercase;
 `;
 
-const PanelWrapper = styled(Panel)`
+const PanelWrapper = styled(Panel)<{ delimiter: boolean }>`
   text-align: left;
+  ${({ delimiter }) =>
+    delimiter ? 'border-bottom: 2px solid #CCCCCC !important;' : ''}
 `;
 
 const LinkStyle = styled.a`

--- a/src/components/AssetMeta/components/DocumentTable.tsx
+++ b/src/components/AssetMeta/components/DocumentTable.tsx
@@ -143,7 +143,7 @@ const TextContainerTop = styled.div`
 const PanelWrapper = styled(Panel)<{ delimiter: boolean }>`
   text-align: left;
   ${({ delimiter }) =>
-    delimiter ? 'border-bottom: 2px solid #CCCCCC !important;' : ''}
+    delimiter ? 'border-bottom: 2px solid #CFCFCF !important;' : ''}
 `;
 
 const LinkStyle = styled.a`

--- a/src/components/AssetMeta/components/DocumentTable.tsx
+++ b/src/components/AssetMeta/components/DocumentTable.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 import { Document, DocumentTableProps } from '../../../interfaces';
 import {
+  getCategoryByCustomSort,
   getCategoryByPriority,
   getDocumentsByCategory,
   getDocumentTitle,
@@ -66,6 +67,7 @@ export class DocumentTable extends React.PureComponent<
       docTypes,
       noDocumentsSign,
       collapseProps,
+      customCategorySort,
     } = this.props;
     const documentsByCategory = getDocumentsByCategory(
       docs || [],
@@ -73,10 +75,12 @@ export class DocumentTable extends React.PureComponent<
       docTypes,
       documentTypeField
     );
-    const { categories, prioritizedCount } = getCategoryByPriority(
-      documentsByCategory,
-      categoryPriorityList
-    );
+    const {
+      categories,
+      prioritizedCount,
+    }: { categories: string[]; prioritizedCount: number } = customCategorySort
+      ? getCategoryByCustomSort(documentsByCategory, customCategorySort)
+      : getCategoryByPriority(documentsByCategory, categoryPriorityList);
 
     if (!categories.length) {
       return (

--- a/src/components/AssetMeta/components/DocumentTable.tsx
+++ b/src/components/AssetMeta/components/DocumentTable.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import styled from 'styled-components';
 import { Document, DocumentTableProps } from '../../../interfaces';
 import {
-  getCategoryByCustomSort,
   getCategoryByPriority,
   getDocumentsByCategory,
   getDocumentTitle,
@@ -75,12 +74,11 @@ export class DocumentTable extends React.PureComponent<
       docTypes,
       documentTypeField
     );
-    const {
-      categories,
-      prioritizedCount,
-    }: { categories: string[]; prioritizedCount: number } = customCategorySort
-      ? getCategoryByCustomSort(documentsByCategory, customCategorySort)
-      : getCategoryByPriority(documentsByCategory, categoryPriorityList);
+    const { categories, prioritizedCount } = getCategoryByPriority(
+      documentsByCategory,
+      categoryPriorityList,
+      customCategorySort
+    );
 
     if (!categories.length) {
       return (

--- a/src/components/AssetMeta/stories/AssetMeta.stories.tsx
+++ b/src/components/AssetMeta/stories/AssetMeta.stories.tsx
@@ -14,6 +14,7 @@ import { ASSET_DATA, DOCUMENTS, EVENTS } from '../../../mocks';
 import { AssetMeta } from '../AssetMeta';
 import alternatePane from './alternatePane.md';
 import basic from './basic.md';
+import customCategorySort from './customCategorySort.md';
 import fullDescription from './full.md';
 import hideTab from './hideTab.md';
 import selectedDocument from './selectedDocument.md';
@@ -115,6 +116,23 @@ storiesOf('AssetMeta/Examples', module)
     {
       readme: {
         content: selectedDocument,
+      },
+    }
+  )
+  .add(
+    'Custom categories sort',
+    () => {
+      const customSort = (a: string, b: string) => (a > b ? -1 : a < b ? 1 : 0);
+      return (
+        <AssetMeta
+          assetId={123}
+          docsProps={{ customCategorySort: customSort }}
+        />
+      );
+    },
+    {
+      readme: {
+        content: customCategorySort,
       },
     }
   );

--- a/src/components/AssetMeta/stories/AssetMeta.stories.tsx
+++ b/src/components/AssetMeta/stories/AssetMeta.stories.tsx
@@ -15,6 +15,8 @@ import { AssetMeta } from '../AssetMeta';
 import alternatePane from './alternatePane.md';
 import basic from './basic.md';
 import customCategorySort from './customCategorySort.md';
+import customPriorityAndSort from './customPriorityAndSort.md';
+import customPriorityCategory from './customPriorityCategory.md';
 import fullDescription from './full.md';
 import hideTab from './hideTab.md';
 import selectedDocument from './selectedDocument.md';
@@ -120,19 +122,58 @@ storiesOf('AssetMeta/Examples', module)
     }
   )
   .add(
+    'Custom priority categories',
+    () => {
+      return (
+        <AssetMeta
+          assetId={123}
+          docsProps={{ categoryPriorityList: ['AB', 'ZE'] }}
+        />
+      );
+    },
+    {
+      readme: {
+        content: customPriorityCategory,
+      },
+    }
+  )
+  .add(
     'Custom categories sort',
     () => {
       const customSort = (a: string, b: string) => (a > b ? -1 : a < b ? 1 : 0);
       return (
         <AssetMeta
           assetId={123}
-          docsProps={{ customCategorySort: customSort }}
+          docsProps={{
+            customCategorySort: customSort,
+            categoryPriorityList: [],
+          }}
         />
       );
     },
     {
       readme: {
         content: customCategorySort,
+      },
+    }
+  )
+  .add(
+    'Custom category priority and sort',
+    () => {
+      const customSort = (a: string, b: string) => (a > b ? -1 : a < b ? 1 : 0);
+      return (
+        <AssetMeta
+          assetId={123}
+          docsProps={{
+            customCategorySort: customSort,
+            categoryPriorityList: ['ZE'],
+          }}
+        />
+      );
+    },
+    {
+      readme: {
+        content: customPriorityAndSort,
       },
     }
   );

--- a/src/components/AssetMeta/stories/customCategorySort.md
+++ b/src/components/AssetMeta/stories/customCategorySort.md
@@ -1,0 +1,23 @@
+## Custom Categories Sort
+
+<!-- STORY -->
+
+#### Usage:
+
+```typescript jsx
+import React from 'react';
+import { AssetMeta } from '@cognite/gearbox';
+
+function ExampleComponent(props) {
+
+  const customCategorySort = (a: string, b: string) => a > b ? -1 : a < b ? 1 : 0;
+
+  return (
+    <AssetMeta 
+      assetId={4650652196144007}
+      docsProps={{customCategorySort}}
+    />
+  );
+  
+}
+```

--- a/src/components/AssetMeta/stories/customPriorityAndSort.md
+++ b/src/components/AssetMeta/stories/customPriorityAndSort.md
@@ -1,4 +1,4 @@
-## Custom Categories Sort
+## Custom Category Priority and Sort
 
 <!-- STORY -->
 
@@ -16,9 +16,9 @@ function ExampleComponent(props) {
     <AssetMeta 
       assetId={4650652196144007}
       docsProps={{
-        customCategorySort,
-        categoryPriorityList: [],
-        }}
+            customCategorySort,
+            categoryPriorityList: ['ZE'],
+          }}
     />
   );
   

--- a/src/components/AssetMeta/stories/customPriorityCategory.md
+++ b/src/components/AssetMeta/stories/customPriorityCategory.md
@@ -1,4 +1,4 @@
-## Custom Categories Sort
+## Custom Priority Categories
 
 <!-- STORY -->
 
@@ -10,15 +10,10 @@ import { AssetMeta } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
 
-  const customCategorySort = (a: string, b: string) => a > b ? -1 : a < b ? 1 : 0;
-
   return (
     <AssetMeta 
       assetId={4650652196144007}
-      docsProps={{
-        customCategorySort,
-        categoryPriorityList: [],
-        }}
+      docsProps={{ categoryPriorityList: ['AB', 'ZE'] }}
     />
   );
   

--- a/src/components/AssetMeta/stories/full.md
+++ b/src/components/AssetMeta/stories/full.md
@@ -43,9 +43,14 @@ function ExampleComponent(props) {
 ### Types
 
 #### MetaDocProps
-This prop is supposed to customize the look of "Documents" pane.
+This prop customizes the appearance of "Documents" pane.
 It also contains a handler triggered when a user clicks on a certain document.
-The type can be imported from @cognite/gearbox:
+Please notice that document categories "P&ID" and "Logic diagrams" are prioritized by default 
+so that these categories always appear on top of the list unless `categoryPriorityList` 
+is provided with a list of prioritized category codes. The rest of categories are sorted alphabetically, 
+but if `customCategorySort` is provided this function will be used for sorting none prioritized categories.
+Priority categories are delimited from regular categories by gray line.
+`MetaDocProps` type can be imported from @cognite/gearbox:
 
 ```typescript
 import { MetaDocProps } from '@cognite/gearbox';

--- a/src/components/AssetMeta/stories/full.md
+++ b/src/components/AssetMeta/stories/full.md
@@ -67,6 +67,7 @@ interface MetaDocProps {
   docTypes?: JsonDocTypes;
   noDocumentsSign?: string;
   documentRenderer?: DocumentRenderer;
+  customCategorySort?: (a: string, b: string) => number;
 }
   
 type OnDocumentClick = (

--- a/src/interfaces/DocumentTypes.ts
+++ b/src/interfaces/DocumentTypes.ts
@@ -54,6 +54,7 @@ export interface MetaDocProps {
   docTypes?: JsonDocTypes;
   noDocumentsSign?: string;
   documentRenderer?: DocumentRenderer;
+  customCategorySort?: (a: string, b: string) => number;
 }
 
 export interface DocumentTableProps extends MetaDocProps {

--- a/src/mocks/documents.ts
+++ b/src/mocks/documents.ts
@@ -49,7 +49,7 @@ export const DOCUMENTS = [
     ...generateDocumentBase(3),
     metadata: {
       DOC_TITLE: 'document title 3',
-      DOC_TYPE: 'XG',
+      DOC_TYPE: 'ZE',
     },
   },
   {
@@ -57,6 +57,13 @@ export const DOCUMENTS = [
     metadata: {
       DOC_TITLE: 'document title 4',
       DOC_TYPE: 'AB',
+    },
+  },
+  {
+    ...generateDocumentBase(5),
+    metadata: {
+      DOC_TITLE: 'document title 5',
+      DOC_TYPE: 'XL',
     },
   },
 ];

--- a/src/mocks/documents.ts
+++ b/src/mocks/documents.ts
@@ -52,6 +52,13 @@ export const DOCUMENTS = [
       DOC_TYPE: 'XG',
     },
   },
+  {
+    ...generateDocumentBase(4),
+    metadata: {
+      DOC_TITLE: 'document title 4',
+      DOC_TYPE: 'AB',
+    },
+  },
 ];
 
 export const DOCUMENT_WITHOUT_TYPE = {

--- a/src/utils/documents.tsx
+++ b/src/utils/documents.tsx
@@ -73,7 +73,8 @@ export const getCategoryName = (
 
 export const getCategoryByPriority = (
   docsByCat: DocumentsByCategory,
-  priorityList: string[] = []
+  priorityList: string[] = [],
+  customSort?: (a: string, b: string) => number
 ): { categories: string[]; prioritizedCount: number } => {
   const priorityObject = getPriorityObjectFromArray(priorityList);
   const prioritizedCategories: string[] = [];
@@ -85,33 +86,16 @@ export const getCategoryByPriority = (
       regularCategories.push(category);
     }
   }
+  const sortFunction = customSort || sortStringsAlphabetically;
   return {
     categories: prioritizedCategories
       .sort((a, b) => sortDocsByPriority(a, b, priorityObject))
       .concat(
         regularCategories.sort((a, b) =>
-          sortStringsAlphabetically(
-            docsByCat[a].description,
-            docsByCat[b].description
-          )
+          sortFunction(docsByCat[a].description, docsByCat[b].description)
         )
       ),
     prioritizedCount: prioritizedCategories.length,
-  };
-};
-
-export const getCategoryByCustomSort = (
-  documentsByCategory: DocumentsByCategory,
-  customSort: (a: string, b: string) => number
-): { categories: string[]; prioritizedCount: number } => {
-  return {
-    categories: Object.keys(documentsByCategory).sort((a, b) =>
-      customSort(
-        documentsByCategory[a].description,
-        documentsByCategory[b].description
-      )
-    ),
-    prioritizedCount: 0,
   };
 };
 

--- a/src/utils/documents.tsx
+++ b/src/utils/documents.tsx
@@ -7,6 +7,7 @@ import {
   PureObject,
 } from '../interfaces';
 import docTypes from './resources/docTypes.json';
+import { sortStringsAlphabetically } from './utils';
 
 const maxDocumentTitleLength = 56;
 const documentTypesOptions = ['DOC_TYPE', 'doc_type'];
@@ -15,9 +16,16 @@ const documentTitleOptions = ['DOC_TITLE', 'title'];
 const getPriorityObjectFromArray = (list: string[]): Priority =>
   list.reduce((acc, p, i) => ({ ...acc, [p]: i + 1 }), {});
 
-const sortDocsByPriority = (a: string, b: string, priority: Priority) =>
-  (priority[a] || Number.MAX_SAFE_INTEGER) -
-  (priority[b] || Number.MAX_SAFE_INTEGER);
+const sortDocsByPriority = (
+  a: string,
+  b: string,
+  priority: Priority
+): number => {
+  return (
+    (priority[a] || Number.MAX_SAFE_INTEGER) -
+    (priority[b] || Number.MAX_SAFE_INTEGER)
+  );
+};
 
 const getValueFromObject = (metadata?: PureObject, arr?: string[]): string => {
   if (!metadata || !arr) {
@@ -66,11 +74,23 @@ export const getCategoryName = (
 export const getCategoryByPriority = (
   docsByCat: DocumentsByCategory,
   priorityList: string[] = []
-) => {
+): { categories: string[]; prioritizedCount: number } => {
   const priorityObject = getPriorityObjectFromArray(priorityList);
-  return Object.keys(docsByCat).sort((a, b) =>
-    sortDocsByPriority(a, b, priorityObject)
-  );
+  const prioritizedCategories: string[] = [];
+  const regularCategories: string[] = [];
+  for (const category of Object.keys(docsByCat)) {
+    if (priorityObject[category] !== undefined) {
+      prioritizedCategories.push(category);
+    } else {
+      regularCategories.push(category);
+    }
+  }
+  return {
+    categories: prioritizedCategories
+      .sort((a, b) => sortDocsByPriority(a, b, priorityObject))
+      .concat(regularCategories.sort(sortStringsAlphabetically)),
+    prioritizedCount: prioritizedCategories.length,
+  };
 };
 
 export const getDocumentsByCategory = (

--- a/src/utils/documents.tsx
+++ b/src/utils/documents.tsx
@@ -100,6 +100,21 @@ export const getCategoryByPriority = (
   };
 };
 
+export const getCategoryByCustomSort = (
+  documentsByCategory: DocumentsByCategory,
+  customSort: (a: string, b: string) => number
+): { categories: string[]; prioritizedCount: number } => {
+  return {
+    categories: Object.keys(documentsByCategory).sort((a, b) =>
+      customSort(
+        documentsByCategory[a].description,
+        documentsByCategory[b].description
+      )
+    ),
+    prioritizedCount: 0,
+  };
+};
+
 export const getDocumentsByCategory = (
   docs: Document[],
   unknownCategoryName?: string,

--- a/src/utils/documents.tsx
+++ b/src/utils/documents.tsx
@@ -88,7 +88,14 @@ export const getCategoryByPriority = (
   return {
     categories: prioritizedCategories
       .sort((a, b) => sortDocsByPriority(a, b, priorityObject))
-      .concat(regularCategories.sort(sortStringsAlphabetically)),
+      .concat(
+        regularCategories.sort((a, b) =>
+          sortStringsAlphabetically(
+            docsByCat[a].description,
+            docsByCat[b].description
+          )
+        )
+      ),
     prioritizedCount: prioritizedCategories.length,
   };
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,6 +4,10 @@ export function clampNumber(v: number, minValue: number, maxValue: number) {
   return Math.max(Math.min(v, maxValue), minValue);
 }
 
+export function sortStringsAlphabetically(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
 export function getCanvas(
   img: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
   width: number,


### PR DESCRIPTION
Show prioritized categories on top of the list.
Make categories "P&ID" and "Logic Diagrams" to be prioritized by default.
Show delimiter (thick line) between prioritized categories and regular categories.
Sort regular categories in alphabetical order by default.
Added prop for custom categories sort.

Fixes #157 