### PR TITLE
EventPreview - fix documentation

### DIFF
--- a/src/components/EventPreview/stories/EventPreview.stories.tsx
+++ b/src/components/EventPreview/stories/EventPreview.stories.tsx
@@ -13,6 +13,7 @@ import hideDescription from './hideDescription.md';
 import hideLoadingSpinner from './hideLoadingSpinner.md';
 import hideMetadata from './hideMetadata.md';
 import hideType from './hideType.md';
+import missingProperties from './missingProperties.md';
 import withCustomText from './withCustomText.md';
 
 Events.retrieve = (eventId: number): Promise<Event> => {
@@ -142,7 +143,7 @@ storiesOf('EventPreview/Examples', module)
     ),
     {
       readme: {
-        content: hideButton,
+        content: missingProperties,
       },
     }
   )

--- a/src/components/EventPreview/stories/missingProperties.md
+++ b/src/components/EventPreview/stories/missingProperties.md
@@ -1,0 +1,21 @@
+## With Missing Properties
+
+<!-- STORY -->
+
+#### Usage:
+
+```typescript jsx
+import React from 'react';
+import { EventPreview } from '@cognite/gearbox';
+
+function ExampleComponent(props) {
+
+  return (
+    <EventPreview 
+      eventId={35593709738145}
+      onShowDetails={onShowDetails}
+    />
+  );
+
+}
+```


### PR DESCRIPTION
Minor fix for EventPreview documentation - added documentation for the story 'With missing properties'.