### PR TITLE
TenantSelector documentation - incorrect image link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/gearbox",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "GearBox will be a place for application developers to contribute useful, reusable components across applications",
   "contributors": [],
   "main": "dist/index.js",

--- a/src/components/TenantSelector/stories/full.md
+++ b/src/components/TenantSelector/stories/full.md
@@ -75,7 +75,7 @@ interface PureObject {
 This interface defines inline CSS styles for inner elements of `TenantSelector` component.
 You can override styles of following blocks:
 
-<img src="/tenant_selector/styling_schema.jpg" alt="Tenant Styling" width="600px">
+<img src="tenant_selector/styling_schema.jpg" alt="Tenant Styling" width="600px">
 <br><br>
 The type can be imported from `@cognite/gearbox`:
 


### PR DESCRIPTION
Use relative reference to the image to fix the link on github pages.
Version update.