### PR TITLE
Updated 3d viewer to 4.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "styled-components": "^4.1.3"
   },
   "optionalDependencies": {
-    "@cognite/3d-viewer": "^4.1.1"
+    "@cognite/3d-viewer": "4.1.3"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/src/components/Model3DViewer/stories/full.md
+++ b/src/components/Model3DViewer/stories/full.md
@@ -4,10 +4,10 @@
 
 #### Requirements:
 
-To use this component you have to install `@cognite/3d-viewer` package (version 4.1.1):
+To use this component you have to install `@cognite/3d-viewer` package (version 4.1.3):
 
 ```bash
-yarn add @cognite/3d-viewer@4.1.1
+yarn add @cognite/3d-viewer@4.1.3
 ```
 
 #### Description:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1240,10 +1240,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@cognite/3d-viewer@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@cognite/3d-viewer/-/3d-viewer-4.1.1.tgz#0442ca62f6089c3e62306835d3e688473a6fbb8e"
-  integrity sha512-Boyd19dAA8Yawutrkl4QLFn00PSQqwKvveA8vIQOo4EpPaQ3kYaZMO/80JmBnQfMSTNHyHwAVuYZl2chift6cg==
+"@cognite/3d-viewer@4.1.3":
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/@cognite/3d-viewer/-/3d-viewer-4.1.3.tgz#3cf478f1d8ae3941eafe533470a46b30e79b6c1a"
+  integrity sha512-71ZilrhSxHc16hrh97ikAwzcR6oud63szNqO7vqMVJ/owfEGpbH4yC+jbLKVYM1kEko8xZuZ3wTsLRxwS5sQ7w==
   dependencies:
     "@cognite/three-combo-controls" "^1.2.5"
     "@tweenjs/tween.js" "^17.2.0"


### PR DESCRIPTION
This version includes an important fix for Chrome 74 on Windows/Linux where large 3D models may crash the browser.