### PR TITLE
Removed highlightNodes on complete

### DIFF
--- a/src/components/Model3DViewer/Model3DViewer.tsx
+++ b/src/components/Model3DViewer/Model3DViewer.tsx
@@ -247,9 +247,7 @@ export class Model3DViewer extends React.Component<Model3DViewerProps> {
 
     this.model.deselectAllNodes();
 
-    if (!length) {
-      this.viewer.fitCameraToModel(this.model);
-    } else if (length === 1) {
+    if (length === 1) {
       const { nodeId } = this.nodes[0];
 
       // @ts-ignore

--- a/src/components/Model3DViewer/Model3DViewer.tsx
+++ b/src/components/Model3DViewer/Model3DViewer.tsx
@@ -275,8 +275,6 @@ export class Model3DViewer extends React.Component<Model3DViewerProps> {
   private onComplete() {
     const { onComplete } = this.props;
 
-    this.highlightNodes();
-
     if (onComplete) {
       onComplete();
     }


### PR DESCRIPTION
Currently, the camera always bounces away from the initial camera position due to an unexpected call to `this.highlightNodes();` in `onComplete` that will call `viewer.fitCameraToModel()`. This moves the camera away from the initial camera position defined in the API.