### PR TITLE
SensorOverlay - renamed timeserieIds prop into timeseriesIds

### DIFF
--- a/src/components/SensorOverlay/SensorOverlay.test.tsx
+++ b/src/components/SensorOverlay/SensorOverlay.test.tsx
@@ -55,7 +55,7 @@ describe('SensorOverlay', () => {
   it('Renders without exploding', () => {
     const wrapper = mount(
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         size={{ width: 1000, height: 500 }}
       />
     );
@@ -66,7 +66,7 @@ describe('SensorOverlay', () => {
   it('Includes all required components', () => {
     const wrapper = mount(
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         size={{ width: 1000, height: 500 }}
       >
         <div style={{ width: 1000, height: 500 }} />
@@ -86,7 +86,7 @@ describe('SensorOverlay', () => {
   it('Calls callbacks on mouse events', () => {
     const wrapper = mount(
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         linksMap={{ [timeseriesList[0].id]: true }}
         onClick={propsCallbacks.onClick}
         onLinkClick={propsCallbacks.onLinkClick}
@@ -133,7 +133,7 @@ describe('SensorOverlay', () => {
   it('Tag and pointer should be draggable', () => {
     const wrapper = mount(
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         linksMap={{ [timeseriesList[0].id]: true }}
         onClick={propsCallbacks.onClick}
         onSensorPositionChange={propsCallbacks.onSensorPositionChange}
@@ -188,7 +188,7 @@ describe('SensorOverlay', () => {
   it('Should render nothing if there is no space in container', () => {
     const wrapper = mount(
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         size={{ width: 1000, height: 0 }}
       />
     );
@@ -206,14 +206,14 @@ describe('SensorOverlay', () => {
   it('Should render new sensors if they were added in props', done => {
     const wrapper = mount(
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         size={{ width: 1000, height: 500 }}
       />
     );
 
     wrapper.setProps(
       {
-        timeserieIds: [timeseriesList[0].id, timeseriesList[1].id],
+        timeseriesIds: [timeseriesList[0].id, timeseriesList[1].id],
       },
       () => {
         const draggableBox = wrapper.find(DraggableBox);
@@ -233,14 +233,14 @@ describe('SensorOverlay', () => {
   it('Newly added sensor should have be shifted position and different color', done => {
     const wrapper = mount(
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         size={{ width: 1000, height: 500 }}
       />
     );
 
     wrapper.setProps(
       {
-        timeserieIds: [timeseriesList[0].id, timeseriesList[1].id],
+        timeseriesIds: [timeseriesList[0].id, timeseriesList[1].id],
       },
       () => {
         const draggableBoxes = wrapper.find(DraggableBox);
@@ -268,7 +268,7 @@ describe('SensorOverlay', () => {
   it('if first sensor has been dragged the next added one should appear in first default slot', done => {
     const wrapper = mount(
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         size={{ width: 1000, height: 500 }}
         onSensorPositionChange={propsCallbacks.onSensorPositionChange}
       >
@@ -304,7 +304,7 @@ describe('SensorOverlay', () => {
 
     wrapper.setProps(
       {
-        timeserieIds: [timeseriesList[0].id, timeseriesList[1].id],
+        timeseriesIds: [timeseriesList[0].id, timeseriesList[1].id],
       },
       () => {
         const newSensor = wrapper
@@ -323,7 +323,7 @@ describe('SensorOverlay', () => {
   it('Sensor should change default color if a new color has been given in colorMap', done => {
     const wrapper = mount(
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         size={{ width: 1000, height: 500 }}
       />
     );
@@ -333,7 +333,7 @@ describe('SensorOverlay', () => {
 
     wrapper.setProps(
       {
-        timeserieIds: [timeseriesList[0].id],
+        timeseriesIds: [timeseriesList[0].id],
         colorMap: {
           [timeseriesList[0].id]: 'magenta',
         },

--- a/src/components/SensorOverlay/SensorOverlay.tsx
+++ b/src/components/SensorOverlay/SensorOverlay.tsx
@@ -86,7 +86,7 @@ interface DraggableBoxPosition extends SensorPosition {
 
 export interface SensorOverlayProps {
   children: React.ReactNode;
-  timeserieIds: number[];
+  timeseriesIds: number[];
   alertColor?: string;
   colorMap: {
     [id: string]: string;
@@ -120,7 +120,7 @@ export interface SensorOverlayProps {
 }
 
 interface SensorOverlayState {
-  timeserieIds: number[]; // reference to timeserieIds in props
+  timeseriesIds: number[]; // reference to timeseriesIds in props
   boxes: DraggableBoxPosition[];
   prevSize: {
     width: number;
@@ -139,7 +139,7 @@ class SensorOverlay extends Component<SensorOverlayProps, SensorOverlayState> {
     state: SensorOverlayState
   ) {
     if (
-      props.timeserieIds !== state.timeserieIds ||
+      props.timeseriesIds !== state.timeseriesIds ||
       props.size.width !== state.prevSize.width ||
       props.size.height !== state.prevSize.height
     ) {
@@ -156,7 +156,7 @@ class SensorOverlay extends Component<SensorOverlayProps, SensorOverlayState> {
     return props.size.width === 0 || props.size.height === 0
       ? {
           // container is empty
-          timeserieIds: props.timeserieIds,
+          timeseriesIds: props.timeseriesIds,
           boxes: [],
           prevSize: {
             width: props.size.width,
@@ -164,7 +164,7 @@ class SensorOverlay extends Component<SensorOverlayProps, SensorOverlayState> {
           },
         }
       : {
-          timeserieIds: props.timeserieIds,
+          timeseriesIds: props.timeseriesIds,
           boxes: SensorOverlay.makeBoxesList(state.boxes, props),
           prevSize: {
             width: props.size.width,
@@ -182,7 +182,7 @@ class SensorOverlay extends Component<SensorOverlayProps, SensorOverlayState> {
       .filter((v): v is number => typeof v === 'number')
       .sort((a: number, b: number) => a - b);
 
-    return props.timeserieIds.map(id => {
+    return props.timeseriesIds.map(id => {
       const oldBox = oldBoxes.find(box => box.id === id);
       if (oldBox) {
         return oldBox;
@@ -247,7 +247,7 @@ class SensorOverlay extends Component<SensorOverlayProps, SensorOverlayState> {
   constructor(props: SensorOverlayProps) {
     super(props);
     this.state = SensorOverlay.getNewStateFromProps(props, {
-      timeserieIds: [],
+      timeseriesIds: [],
       boxes: [],
       prevSize: {
         width: 0,

--- a/src/components/SensorOverlay/stories/SensorOverlay.stories.tsx
+++ b/src/components/SensorOverlay/stories/SensorOverlay.stories.tsx
@@ -39,7 +39,7 @@ sdk.Datapoints.retrieveLatest = async (name: string): Promise<Datapoint> => {
 storiesOf('SensorOverlay', module).add(
   'Full description',
   () => (
-    <SensorOverlay timeserieIds={[timeseriesList[0].id]}>
+    <SensorOverlay timeseriesIds={[timeseriesList[0].id]}>
       <div style={{ width: '100%', height: '160px', background: '#EEE' }} />
     </SensorOverlay>
   ),
@@ -54,7 +54,7 @@ storiesOf('SensorOverlay/Examples', module)
   .add(
     'Basic',
     () => (
-      <SensorOverlay timeserieIds={[timeseriesList[0].id]}>
+      <SensorOverlay timeseriesIds={[timeseriesList[0].id]}>
         <div style={{ width: '100%', height: '200px', background: '#EEE' }} />
       </SensorOverlay>
     ),
@@ -68,7 +68,7 @@ storiesOf('SensorOverlay/Examples', module)
     'With many sensors',
     () => (
       <SensorOverlay
-        timeserieIds={[
+        timeseriesIds={[
           timeseriesList[0].id,
           timeseriesList[1].id,
           timeseriesList[2].id,
@@ -88,7 +88,7 @@ storiesOf('SensorOverlay/Examples', module)
     'Default position and color',
     () => (
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         colorMap={{ [timeseriesList[0].id]: '#33AA33' }}
         defaultPositionMap={{
           [timeseriesList[0].id]: {
@@ -117,7 +117,7 @@ storiesOf('SensorOverlay/Examples', module)
     'Disabled Dragging',
     () => (
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         isTagDraggable={false}
         isPointerDraggable={false}
       >
@@ -134,7 +134,7 @@ storiesOf('SensorOverlay/Examples', module)
     'With link',
     () => (
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         linksMap={{ [timeseriesList[0].id]: true }}
         onClick={action('onClick')}
         onLinkClick={action('onLinkClick')}
@@ -154,7 +154,7 @@ storiesOf('SensorOverlay/Examples', module)
     'With sticky tooltips',
     () => (
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         stickyMap={{ [8681821313339919]: true }}
         defaultPositionMap={{
           [8681821313339919]: {
@@ -180,7 +180,7 @@ storiesOf('SensorOverlay/Examples', module)
     'With min-max limit',
     () => (
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         stickyMap={{ [8681821313339919]: true }}
         alertColor={'magenta'}
         minMaxMap={{
@@ -203,7 +203,7 @@ storiesOf('SensorOverlay/Examples', module)
     'With Image',
     () => (
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         colorMap={{ [timeseriesList[0].id]: 'orange' }}
         defaultPositionMap={{
           [timeseriesList[0].id]: {
@@ -235,7 +235,7 @@ storiesOf('SensorOverlay/Examples', module)
     'With Fixed Width',
     () => (
       <SensorOverlay
-        timeserieIds={[timeseriesList[0].id]}
+        timeseriesIds={[timeseriesList[0].id]}
         colorMap={{ [timeseriesList[0].id]: 'orange' }}
         defaultPositionMap={{
           [timeseriesList[0].id]: {
@@ -270,7 +270,7 @@ storiesOf('SensorOverlay/Examples', module)
       class WrapperComponent extends React.Component {
         state = {
           counter: 0,
-          timeserieIds: [],
+          timeseriesIds: [],
         };
         render() {
           return (
@@ -279,8 +279,8 @@ storiesOf('SensorOverlay/Examples', module)
                 style={{ marginBottom: 20 }}
                 onClick={() =>
                   this.setState({
-                    timeserieIds: [
-                      ...this.state.timeserieIds,
+                    timeseriesIds: [
+                      ...this.state.timeseriesIds,
                       timeseriesList[this.state.counter].id,
                     ],
                     counter: this.state.counter + 1,
@@ -289,7 +289,7 @@ storiesOf('SensorOverlay/Examples', module)
               >
                 Add Sensor
               </button>
-              <SensorOverlay timeserieIds={this.state.timeserieIds}>
+              <SensorOverlay timeseriesIds={this.state.timeseriesIds}>
                 <div
                   style={{
                     width: '100%',

--- a/src/components/SensorOverlay/stories/addDynamically.md
+++ b/src/components/SensorOverlay/stories/addDynamically.md
@@ -9,12 +9,12 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { SensorOverlay } from '@cognite/gearbox';
-import { timeseriesList } from './timeseriesList'; // sample list of timeseries 
+import { timeseriesList } from './timeseriesList'; // sample list of timeseries
 
 class ExampleComponent extends React.Component {
   state = {
     counter: 0,
-    timeserieIds: [],
+    timeseriesIds: [],
   };
   render() {
     return (
@@ -23,8 +23,8 @@ class ExampleComponent extends React.Component {
           style={{ marginBottom: 20 }}
           onClick={() =>
             this.setState({
-              timeserieIds: [
-                ...this.state.timeserieIds,
+              timeseriesIds: [
+                ...this.state.timeseriesIds,
                 timeseriesList[this.state.counter].id,
               ],
               counter: this.state.counter + 1,
@@ -33,7 +33,7 @@ class ExampleComponent extends React.Component {
         >
           Add Sensor
         </button>
-        <SensorOverlay timeserieIds={this.state.timeserieIds}>
+        <SensorOverlay timeseriesIds={this.state.timeseriesIds}>
           <div
             style={{
               width: '100%',
@@ -45,6 +45,6 @@ class ExampleComponent extends React.Component {
       </div>
     );
   }
-
+  
 }
 ```

--- a/src/components/SensorOverlay/stories/basic.md
+++ b/src/components/SensorOverlay/stories/basic.md
@@ -1,4 +1,4 @@
-## Basic 
+## Basic
 
 <!-- STORY -->
 
@@ -11,13 +11,13 @@ import React from 'react';
 import { SensorOverlay } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const timeserieIds = [ 8681821313339919 ];
+  const timeseriesIds = [8681821313339919];
 
   return (
-    <SensorOverlay timeserieIds={ timeserieIds }>
+    <SensorOverlay timeseriesIds={timeseriesIds}>
       <div style={{ width: '100%', height: '200px', background: '#EEE' }} />
     </SensorOverlay>
   );
-
+  
 }
 ```

--- a/src/components/SensorOverlay/stories/defaultPosition.md
+++ b/src/components/SensorOverlay/stories/defaultPosition.md
@@ -1,4 +1,4 @@
-## With Default Position and Custom Color 
+## With Default Position and Custom Color
 
 <!-- STORY -->
 
@@ -11,14 +11,17 @@ import React from 'react';
 import { SensorOverlay, SensorPosition } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const timeserieIds = [  8681821313339919 ];
+  const timeseriesIds = [8681821313339919];
   const handleClick = (timeserieId: number) => {};
   const handleSettingsClick = (timeserieId: number) => {};
-  const handlePositionChange = (timeserieId: number, position: SensorPosition) => {};
+  const handlePositionChange = (
+    timeserieId: number,
+    position: SensorPosition
+  ) => {};
 
   return (
     <SensorOverlay
-      timeserieIds={timeserieIds}
+      timeseriesIds={timeseriesIds}
       colorMap={{ [8681821313339919]: '#33AA33' }}
       defaultPositionMap={{
         [8681821313339919]: {
@@ -37,6 +40,6 @@ function ExampleComponent(props) {
       <div style={{ width: '100%', height: '250px', background: '#EEE' }} />
     </SensorOverlay>
   );
-
+  
 }
 ```

--- a/src/components/SensorOverlay/stories/disabledDragging.md
+++ b/src/components/SensorOverlay/stories/disabledDragging.md
@@ -1,4 +1,4 @@
-## Disabled Dragging 
+## Disabled Dragging
 
 <!-- STORY -->
 
@@ -11,17 +11,17 @@ import React from 'react';
 import { SensorOverlay } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const timeserieIds = [ 8681821313339919 ];
+  const timeseriesIds = [8681821313339919];
 
   return (
     <SensorOverlay
-      timeserieIds={ timeserieIds }
+      timeseriesIds={timeseriesIds}
       isTagDraggable={false}
       isPointerDraggable={false}
     >
       <div style={{ width: '100%', height: '200px', background: '#EEE' }} />
     </SensorOverlay>
   );
-
+  
 }
 ```

--- a/src/components/SensorOverlay/stories/full.md
+++ b/src/components/SensorOverlay/stories/full.md
@@ -7,7 +7,7 @@
 Renders set of latest timeseries (sensors) data. Each sensor is represented as a draggable box (tag) connected by line with round pointer. All sensor items are drawn on top of wrapped content.
 This component can be used as a container of an infographic image for displaying real-time sensors data.
 The height of SensorOverlay component is defined by content in `children` and the width takes `100%` unless `fixedWidth` is provided. This component requires a list of timeserie IDs and once they are passed via
-`timeserieIds` prop SensorOverlay fetches meta information (name, description, etc) for all timeseries in the list and then constantly fetches latest data (Datapoint) for each timeserie with interval provided in `refreshInterval` (5 seconds by default).
+`timeseriesIds` prop SensorOverlay fetches meta information (name, description, etc) for all timeseries in the list and then constantly fetches latest data (Datapoint) for each timeserie with interval provided in `refreshInterval` (5 seconds by default).
 
 #### Usage:
 
@@ -18,10 +18,10 @@ import React from 'react';
 import { SensorOverlay } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const timeserieIds = [ 8681821313339919 ];
+  const timeseriesIds = [ 8681821313339919 ];
 
   return (
-    <SensorOverlay timeserieIds={ timeserieIds }>
+    <SensorOverlay timeseriesIds={ timeseriesIds }>
       <div style={{ width: '100%', height: '160px', background: '#EEE' }} />
     </SensorOverlay>,
   );
@@ -34,7 +34,7 @@ function ExampleComponent(props) {
 
 | Property              | Description                                                        | Type                  | Default |
 | --------------------- | ------------------------------------------------------------------ | --------------------- | ------- |
-| `timeserieIds`        | List of timeserie Ids                                              | `number[]`            |         |
+| `timeseriesIds`        | List of timeserie Ids                                              | `number[]`            |         |
 | `children`            | Wrapped content. Usually infographic image.                        | `React.ReactNode`     |         |
 
 ##### Optionals:
@@ -43,7 +43,7 @@ function ExampleComponent(props) {
 | --------------------- | ---------------------------------------------------------------- | ---------------------------------- | ------- |
 | `refreshInterval`     | Number in milliseconds that defines refresh interval for fetching latest timeserie data | number      | 5000    |
 | `colorMap`            | Object map that defines custom colors for timeseries             | { [timeserieId: number]: string }  |         |
-| `defaultPositionMap`  | Object map that defines position of newly added sensors in `timeserieIds`. The map doesn't affect position of previously added or dragged sensors.         | { [timeserieId: number]: SensorPosition }  |          |
+| `defaultPositionMap`  | Object map that defines position of newly added sensors in `timeseriesIds`. The map doesn't affect position of previously added or dragged sensors.         | { [timeserieId: number]: SensorPosition }  |          |
 | `skickyMap`           | Object map that defines which timeseries will show tooltips with name and description without mouse hovering  | { [timeserieId: number]: boolean } |       |
 | `minMaxMap`           | Object map that defines a normal range for sensor values and once the value is out of this range an alert bar will be shown | { [timeserieId: number]: SensorMinMaxRange } |       |
 | `linksMap`            | Object map that defines if it's needed to wrap timeserie values in the anchor tag `<a>`, works in conjunction with `onLinkClick` | { [timeserieId: number]: boolean } |       |

--- a/src/components/SensorOverlay/stories/withFixedWidth.md
+++ b/src/components/SensorOverlay/stories/withFixedWidth.md
@@ -11,14 +11,17 @@ import React from 'react';
 import { SensorOverlay, SensorPosition } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const timeserieIds = [  8681821313339919 ];
+  const timeseriesIds = [8681821313339919];
   const handleClick = (timeserieId: number) => {};
   const handleSettingsClick = (timeserieId: number) => {};
-  const handlePositionChange = (timeserieId: number, position: SensorPosition) => {};
+  const handlePositionChange = (
+    timeserieId: number,
+    position: SensorPosition
+  ) => {};
 
   return (
     <SensorOverlay
-      timeserieIds={ timeserieIds }
+      timeseriesIds={timeseriesIds}
       colorMap={{ [8681821313339919]: 'orange' }}
       defaultPositionMap={{
         [8681821313339919]: {
@@ -41,6 +44,6 @@ function ExampleComponent(props) {
       />
     </SensorOverlay>
   );
-
+  
 }
 ```

--- a/src/components/SensorOverlay/stories/withImage.md
+++ b/src/components/SensorOverlay/stories/withImage.md
@@ -11,14 +11,17 @@ import React from 'react';
 import { SensorOverlay, SensorPosition } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const timeserieIds = [  8681821313339919 ];
+  const timeseriesIds = [8681821313339919];
   const handleClick = (timeserieId: number) => {};
   const handleSettingsClick = (timeserieId: number) => {};
-  const handlePositionChange = (timeserieId: number, position: SensorPosition) => {};
+  const handlePositionChange = (
+    timeserieId: number,
+    position: SensorPosition
+  ) => {};
 
   return (
     <SensorOverlay
-      timeserieIds={ timeserieIds }
+      timeseriesIds={timeseriesIds}
       colorMap={{ [8681821313339919]: 'orange' }}
       defaultPositionMap={{
         [8681821313339919]: {
@@ -40,6 +43,6 @@ function ExampleComponent(props) {
       />
     </SensorOverlay>
   );
-
+  
 }
 ```

--- a/src/components/SensorOverlay/stories/withLink.md
+++ b/src/components/SensorOverlay/stories/withLink.md
@@ -12,13 +12,13 @@ import { SensorOverlay } from '@cognite/gearbox';
 import { Datapoint } from '@cognite/sdk';
 
 function ExampleComponent(props) {
-  const timeserieIds = [ 8681821313339919 ];
+  const timeseriesIds = [8681821313339919];
   const handleClick = (timeserieId: number) => {};
   const handleLinkClick = (timeserieId: number, datapoint: Datapoint) => {};
 
   return (
     <SensorOverlay
-      timeserieIds={ timeserieIds }
+      timeseriesIds={timeseriesIds}
       linksMap={{ [8681821313339919]: true }}
       onClick={handleClick}
       onLinkClick={handleLinkClick}
@@ -26,6 +26,6 @@ function ExampleComponent(props) {
       <div style={{ width: '100%', height: '200px', background: '#EEE' }} />
     </SensorOverlay>
   );
-
+  
 }
 ```

--- a/src/components/SensorOverlay/stories/withMany.md
+++ b/src/components/SensorOverlay/stories/withMany.md
@@ -1,4 +1,4 @@
-## With Many Sensors 
+## With Many Sensors
 
 <!-- STORY -->
 
@@ -11,7 +11,7 @@ import React from 'react';
 import { SensorOverlay } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const timeserieIds = [ 
+  const timeseriesIds = [
     8681821313339919,
     4965555138606429,
     1762612637163055,
@@ -19,10 +19,10 @@ function ExampleComponent(props) {
   ];
 
   return (
-    <SensorOverlay timeserieIds={ timeserieIds }>
+    <SensorOverlay timeseriesIds={timeseriesIds}>
       <div style={{ width: '100%', height: '220px', background: '#EEE' }} />
     </SensorOverlay>
   );
-
+  
 }
 ```

--- a/src/components/SensorOverlay/stories/withMinMax.md
+++ b/src/components/SensorOverlay/stories/withMinMax.md
@@ -11,11 +11,11 @@ import React from 'react';
 import { SensorOverlay } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const timeserieIds = [ 8681821313339919 ];
+  const timeseriesIds = [8681821313339919];
 
   return (
     <SensorOverlay
-      timeserieIds={timeserieIds}
+      timeseriesIds={timeseriesIds}
       stickyMap={{ [8681821313339919]: true }}
       alertColor={'magenta'}
       minMaxMap={{
@@ -28,6 +28,6 @@ function ExampleComponent(props) {
       <div style={{ width: '100%', height: '250px', background: '#EEE' }} />
     </SensorOverlay>
   );
-
+  
 }
 ```

--- a/src/components/SensorOverlay/stories/withStickyTooltips.md
+++ b/src/components/SensorOverlay/stories/withStickyTooltips.md
@@ -11,11 +11,11 @@ import React from 'react';
 import { SensorOverlay } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const timeserieIds = [ 8681821313339919 ];
+  const timeseriesIds = [8681821313339919];
 
   return (
     <SensorOverlay
-      timeserieIds={timeserieIds}
+      timeseriesIds={timeseriesIds}
       stickyMap={{ [8681821313339919]: true }}
       defaultPositionMap={{
         [8681821313339919]: {
@@ -31,6 +31,6 @@ function ExampleComponent(props) {
       <div style={{ width: '100%', height: '250px', background: '#EEE' }} />
     </SensorOverlay>
   );
-
+  
 }
 ```


### PR DESCRIPTION
For purposes of unification, prop `timeserieIds` has been renamed into `timeseriesIds`.

Closes #240 