### PR TITLE
Add path to typescript declaration files in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "contributors": [],
   "main": "dist/index.js",
   "module": "dist/index.es.js",
+  "types": "dist/index.d.ts",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Fixes #275 

Fix IDE autocomplete issue in case of importing typescript types/components.

Before you have to use import like:
```typescript
import { COMPONENT } from '@cognite/gearbox/dist'
```
Now:
```typescript
import { COMPONENT } from '@cognite/gearbox'
```