### PR TITLE
HOCs - Add prop for SDK list call

### DIFF
--- a/src/components/AssetDocumentsPanel/stories/full.md
+++ b/src/components/AssetDocumentsPanel/stories/full.md
@@ -34,6 +34,7 @@ function ExampleComponent(props) {
 
 | Property              | Description                                                            | Type                                          | Default     |
 | --------------------- | ---------------------------------------------------------------------- | --------------------------------------------- | ----------- |
+| `queryParams`         | Additional parameters for SDK call. Please notice that `assetId` provided in props will override the one in `queryParams`| `FileListParams` | `{ limit: 1000 }` |
 | `handleDocumentClick` | Callback function triggered when user clicks on a file (document)      | `OnDocumentClick`                             |             |
 | `collapseProps`       | Object with props to be passed to `atnd` `Collapse` component          | `CollapseProps`                               |             |
 | `categoryPriorityList`| List of categories codes to be shown on the top of the list. Categories "P&ID" and "Logic Diagrams" are prioritized by default.| `string[]`                                    | `['XB', 'XL']`|
@@ -47,6 +48,14 @@ function ExampleComponent(props) {
 
 
 ### Types
+
+#### FileListParams
+
+This type can be imported from `@cognite/sdk`:
+
+```typescript
+import { FileListParams } from `@cognite/sdk`;
+```
 
 #### OnDocumentClick
 

--- a/src/components/AssetEventsPanel/stories/full.md
+++ b/src/components/AssetEventsPanel/stories/full.md
@@ -34,12 +34,21 @@ function ExampleComponent(props) {
 
 | Property              | Description                                                                | Type                                          | Default     |
 | --------------------- | -------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
+| `queryParams`         | Additional parameters for SDK call. Please notice that `assetId` provided in props will override the one in `queryParams`| `EventListParams` | `{ limit: 1000 }` |
 | `columns`             | Array of objects that customize titles of the columns in the table         | `TableColumnType[]`                           |             |
 | `customSpinner`       | A custom spinner to be shown in tabs while data is being loaded            | `React.ReactNode`                             |             |
 | `styles`              | Object that defines inline CSS styles for inner elements of the component  | `AssetEventsPanelStyles`                      |             |
 
 
 ### Types
+
+#### EventListParams
+
+This type can be imported from `@cognite/sdk`:
+
+```typescript
+import { EventListParams } from `@cognite/sdk`;
+```
 
 #### TableColumnType
 

--- a/src/components/AssetTimeseriesPanel/stories/full.md
+++ b/src/components/AssetTimeseriesPanel/stories/full.md
@@ -34,9 +34,18 @@ function ExampleComponent(props) {
 
 | Property              | Description                                                            | Type                                          | Default     |
 | --------------------- | ---------------------------------------------------------------------- | --------------------------------------------- | ----------- |
+| `queryParams`         | Additional parameters for SDK call. Please notice that `assetId` provided in props will override the one in `queryParams`| `TimeseriesListParams` | `{ limit: 1000 }` |
 | `customSpinner`       | A custom spinner to be shown in tabs while data is being loaded        | `React.ReactNode`                             |             |
 | `strings`             | Object that defines strings to be passed to the component              | `{ noTimeseriesSign?: string }`               | `'No timeseries linked to this asset'`|                  
 
 #### Optional Props for TimeseriesChartMeta:
 
 This component also takes all optional props of `TimeseriesChartMeta` component. These props are passed to every instance of `TimeseriesChartMeta` in the list of timeseries. See `TimeseriesChartMeta` component for more details.
+
+#### TimeseriesListParams
+
+This type can be imported from `@cognite/sdk`:
+
+```typescript
+import { TimeseriesListParams } from `@cognite/sdk`;
+```

--- a/src/constants/sdk.ts
+++ b/src/constants/sdk.ts
@@ -1,0 +1,1 @@
+export const SDK_LIST_LIMIT = 1000;

--- a/src/hoc/tests/withAssetEvents.test.tsx
+++ b/src/hoc/tests/withAssetEvents.test.tsx
@@ -2,6 +2,7 @@ import * as sdk from '@cognite/sdk';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
+import { SDK_LIST_LIMIT } from '../../constants/sdk';
 import { EVENTS } from '../../mocks';
 import { withAssetEvents, WithAssetEventsDataProps } from '../withAssetEvents';
 
@@ -101,6 +102,32 @@ describe('withAssetEvents', () => {
     setImmediate(() => {
       expect(WrappedComponent.prototype.setState).not.toHaveBeenCalled();
       done();
+    });
+  });
+
+  it('Should merge query params with assetId', () => {
+    const WrappedComponent = withAssetEvents(() => <div />);
+    mount(
+      <WrappedComponent
+        assetId={123}
+        queryParams={{ limit: 78, sort: 'sort option' }}
+      />
+    );
+
+    expect(sdk.Events.list).toBeCalledWith({
+      assetId: 123,
+      limit: 78,
+      sort: 'sort option',
+    });
+  });
+
+  it('Should call sdk.Events.list with default limit', () => {
+    const WrappedComponent = withAssetEvents(() => <div />);
+    mount(<WrappedComponent assetId={123} />);
+
+    expect(sdk.Events.list).toBeCalledWith({
+      assetId: 123,
+      limit: SDK_LIST_LIMIT,
     });
   });
 });

--- a/src/hoc/tests/withAssetFiles.test.tsx
+++ b/src/hoc/tests/withAssetFiles.test.tsx
@@ -2,6 +2,7 @@ import * as sdk from '@cognite/sdk';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
+import { SDK_LIST_LIMIT } from '../../constants/sdk';
 import { DOCUMENTS } from '../../mocks';
 import { withAssetFiles, WithAssetFilesDataProps } from '../withAssetFiles';
 
@@ -99,6 +100,32 @@ describe('withAssetFiles', () => {
     setImmediate(() => {
       expect(WrappedComponent.prototype.setState).not.toHaveBeenCalled();
       done();
+    });
+  });
+
+  it('Should merge query params with assetId', () => {
+    const WrappedComponent = withAssetFiles(() => <div />);
+    mount(
+      <WrappedComponent
+        assetId={123}
+        queryParams={{ assetId: 34234, limit: 78, sort: 'sort option' }}
+      />
+    );
+
+    expect(sdk.Files.list).toBeCalledWith({
+      assetId: 123,
+      limit: 78,
+      sort: 'sort option',
+    });
+  });
+
+  it('Should call sdk.Events.list with default limit', () => {
+    const WrappedComponent = withAssetFiles(() => <div />);
+    mount(<WrappedComponent assetId={123} />);
+
+    expect(sdk.Files.list).toBeCalledWith({
+      assetId: 123,
+      limit: SDK_LIST_LIMIT,
     });
   });
 });

--- a/src/hoc/tests/withAssetTimeseries.test.tsx
+++ b/src/hoc/tests/withAssetTimeseries.test.tsx
@@ -2,6 +2,7 @@ import * as sdk from '@cognite/sdk';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
+import { SDK_LIST_LIMIT } from '../../constants/sdk';
 import { timeseriesList } from '../../mocks';
 import {
   withAssetTimeseries,
@@ -106,6 +107,32 @@ describe('withAssetTimeseries', () => {
     setImmediate(() => {
       expect(WrappedComponent.prototype.setState).not.toHaveBeenCalled();
       done();
+    });
+  });
+
+  it('Should merge query params with assetId', () => {
+    const WrappedComponent = withAssetTimeseries(() => <div />);
+    mount(
+      <WrappedComponent
+        assetId={123}
+        queryParams={{ assetId: 34234, limit: 78, path: 'some patth' }}
+      />
+    );
+
+    expect(sdk.TimeSeries.list).toBeCalledWith({
+      assetId: 123,
+      limit: 78,
+      path: 'some patth',
+    });
+  });
+
+  it('Should call sdk.TimeSeries.list with default limit', () => {
+    const WrappedComponent = withAssetTimeseries(() => <div />);
+    mount(<WrappedComponent assetId={123} />);
+
+    expect(sdk.TimeSeries.list).toBeCalledWith({
+      assetId: 123,
+      limit: SDK_LIST_LIMIT,
     });
   });
 });

--- a/src/hoc/withAssetEvents.tsx
+++ b/src/hoc/withAssetEvents.tsx
@@ -1,8 +1,9 @@
-import { Event } from '@cognite/sdk';
+import { Event, EventListParams } from '@cognite/sdk';
 import * as sdk from '@cognite/sdk';
 import React from 'react';
 import { Subtract } from 'utility-types';
 import { LoadingBlock } from '../components/common/LoadingBlock/LoadingBlock';
+import { SDK_LIST_LIMIT } from '../constants/sdk';
 import {
   CanceledPromiseException,
   ComponentWithUnmountState,
@@ -15,6 +16,7 @@ export interface WithAssetEventsDataProps {
 
 export interface WithAssetEventsProps {
   assetId: number;
+  queryParams?: EventListParams;
   customSpinner?: React.ReactNode;
   onAssetEventsLoaded?: (assetEvents: Event[]) => void;
 }
@@ -77,9 +79,14 @@ export const withAssetEvents = <P extends WithAssetEventsDataProps>(
 
     async loadAssetEvents() {
       try {
+        const { assetId, queryParams } = this.props;
         const res = await connectPromiseToUnmountState(
           this,
-          sdk.Events.list({ assetId: this.props.assetId, limit: 1000 })
+          sdk.Events.list({
+            limit: SDK_LIST_LIMIT,
+            ...queryParams,
+            assetId,
+          })
         );
 
         this.setState({

--- a/src/hoc/withAssetFiles.tsx
+++ b/src/hoc/withAssetFiles.tsx
@@ -1,8 +1,9 @@
-import { File } from '@cognite/sdk';
+import { File, FileListParams } from '@cognite/sdk';
 import * as sdk from '@cognite/sdk';
 import React from 'react';
 import { Subtract } from 'utility-types';
 import { LoadingBlock } from '../components/common/LoadingBlock/LoadingBlock';
+import { SDK_LIST_LIMIT } from '../constants/sdk';
 import {
   CanceledPromiseException,
   ComponentWithUnmountState,
@@ -15,6 +16,7 @@ export interface WithAssetFilesDataProps {
 
 export interface WithAssetFilesProps {
   assetId: number;
+  queryParams?: FileListParams;
   customSpinner?: React.ReactNode;
   onAssetFilesLoaded?: (assetFiles: File[]) => void;
 }
@@ -77,9 +79,14 @@ export const withAssetFiles = <P extends WithAssetFilesDataProps>(
 
     async loadAssetFiles() {
       try {
+        const { assetId, queryParams } = this.props;
         const filesRes = await connectPromiseToUnmountState(
           this,
-          sdk.Files.list({ assetId: this.props.assetId, limit: 1000 })
+          sdk.Files.list({
+            limit: SDK_LIST_LIMIT,
+            ...queryParams,
+            assetId,
+          })
         );
 
         this.setState({

--- a/src/hoc/withAssetTimeseries.tsx
+++ b/src/hoc/withAssetTimeseries.tsx
@@ -1,8 +1,9 @@
-import { Timeseries } from '@cognite/sdk';
+import { Timeseries, TimeseriesListParams } from '@cognite/sdk';
 import * as sdk from '@cognite/sdk';
 import React from 'react';
 import { Subtract } from 'utility-types';
 import { LoadingBlock } from '../components/common/LoadingBlock/LoadingBlock';
+import { SDK_LIST_LIMIT } from '../constants/sdk';
 import {
   CanceledPromiseException,
   ComponentWithUnmountState,
@@ -15,6 +16,7 @@ export interface WithAssetTimeseriesDataProps {
 
 export interface WithAssetTimeseriesProps {
   assetId: number;
+  queryParams?: TimeseriesListParams;
   customSpinner?: React.ReactNode;
   onAssetTimeseriesLoaded?: (assetTimeseries: Timeseries[]) => void;
 }
@@ -77,9 +79,14 @@ export const withAssetTimeseries = <P extends WithAssetTimeseriesDataProps>(
 
     async loadAssetTimeseries() {
       try {
+        const { assetId, queryParams } = this.props;
         const res = await connectPromiseToUnmountState(
           this,
-          sdk.TimeSeries.list({ assetId: this.props.assetId, limit: 1000 })
+          sdk.TimeSeries.list({
+            limit: SDK_LIST_LIMIT,
+            ...queryParams,
+            assetId,
+          })
         );
 
         this.setState({


### PR DESCRIPTION
In HOCs that request lists from SDK added props `queryParams` to be passed to the SDK calls.
Updated documentation for `AssetFilesPanel`, `AssetDocumentsPanel`, `AssetEventsPanel`, 

Closes #297 