### PR TITLE
Using three 0.98, same as the viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "sinon": "^7.2.7",
     "storybook-readme": "^5.0.2",
     "styled-components": "^4.1.3",
-    "three": "^0.104.0",
+    "three": "0.98",
     "ts-jest": "^24.0.0",
     "tslint": "^5.12.1",
     "tslint-config-prettier": "^1.18.0",

--- a/src/components/Model3DViewer/Model3DViewer.tsx
+++ b/src/components/Model3DViewer/Model3DViewer.tsx
@@ -274,6 +274,7 @@ export class Model3DViewer extends React.Component<Model3DViewerProps> {
     if (length === 1) {
       const { nodeId } = this.nodes[0];
 
+      // @ts-ignore
       this.model.updateMatrixWorld();
 
       const reusableBox = new THREE.Box3();

--- a/yarn.lock
+++ b/yarn.lock
@@ -11934,15 +11934,10 @@ text-table@0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@0.98.0:
+three@0.98, three@0.98.0:
   version "0.98.0"
   resolved "https://registry.yarnpkg.com/three/-/three-0.98.0.tgz#11d4e3cca4b5d099c7de0ea5afa153b5d20cda84"
   integrity sha512-fihjYVjCmQbI03zt1+YCl/m+UrZCcDHFNLexgqBOIdPwnO6PYkQaYUsIbqtvNNse+BiMeu+pQWzZn9/NSnIv6A==
-
-three@^0.104.0:
-  version "0.104.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.104.0.tgz#9ad1da492153b753a89e0df066631215bd9d9087"
-  integrity sha512-q617IMBC5k40U2E9UC4/LtmhzTOOLB1jGMIooUL+QrhZ7abiGCSDrKrpCDt9V8RTl6xw+0FYfA1PYsIPKbQOgg==
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
The viewer uses three 0.98, so we should use the same in gearbox. 

One reason is if you use `yarn link` to use local version of gearbox, it does not work well due to incompatible three versions.