### PR TITLE
SDK 2.0: Clean Out old SDK types

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,14 +1,8 @@
 import {
   Asset,
   Assets,
-  Event,
-  Events,
-  File,
-  Files,
   Revision,
   ThreeD,
-  TimeSeries,
-  Timeseries,
 } from '@cognite/sdk';
 import { ApiAssetList } from '../interfaces';
 
@@ -37,50 +31,4 @@ export function fetch3DModelRevision(
   revisionId: number
 ): Promise<Revision> {
   return ThreeD.retrieveRevision(modelId, revisionId);
-}
-
-export async function retrieveAsset(assetId: number) {
-  return await Assets.retrieve(assetId);
-}
-
-export async function getAssetListDescendants(
-  assetId: number,
-  query: { [name: string]: any }
-) {
-  const response = await Assets.listDescendants(assetId, query);
-
-  if (!response.items || response.items.length < 1) {
-    return [];
-  }
-
-  return response.items;
-}
-
-export async function getAssetEvent(query: {
-  assetId: number;
-  limit: number;
-}): Promise<Event[]> {
-  const response = await Events.list(query);
-
-  if (response.items && response.items.length > 0) {
-    return response.items;
-  }
-
-  return [];
-}
-
-export async function getAssetFiles(query: {
-  assetId: number;
-  limit: number;
-}): Promise<File[]> {
-  const response = await Files.list(query);
-  return response.items;
-}
-
-export async function getAssetTimeseries(query: {
-  assetId: number;
-  limit: number;
-}): Promise<Timeseries[]> {
-  const response = await TimeSeries.list(query);
-  return response.items;
 }

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -1,9 +1,4 @@
-import {
-  Asset,
-  Assets,
-  Revision,
-  ThreeD,
-} from '@cognite/sdk';
+import { Asset, Assets, Revision, ThreeD } from '@cognite/sdk';
 import { ApiAssetList } from '../interfaces';
 
 export async function getAssetList({

--- a/src/components/AssetDocumentsPanel/stories/full.md
+++ b/src/components/AssetDocumentsPanel/stories/full.md
@@ -83,12 +83,12 @@ import { CollapseProps } from 'antd/lib/collapse';
 Definition:
 
 ```typescript
-import { FileMetadata } from `@cognite/sdk/dist/src/types/types`;
+import { FilesMetadata } from `@cognite/sdk/dist/src/types/types`;
 
 type DocumentRenderer = (
-  document: FileMetadata,
+  document: FilesMetadata,
   i: number,
-  documents: FileMetadata[]
+  documents: FilesMetadata[]
 
 ) => React.ReactNode;
 

--- a/src/components/AssetDocumentsPanel/stories/loadCallback.md
+++ b/src/components/AssetDocumentsPanel/stories/loadCallback.md
@@ -8,12 +8,12 @@
 import 'antd/dist/antd.css';
 
 import React from 'react';
-import { File } from '@cognite/sdk';
+import { FilesMetadata } from '@cognite/sdk';
 import { AssetDocumentsPanel } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
 
-  const handleAssetFilesLoaded = (files: File[]) => { };
+  const handleAssetFilesLoaded = (files: FilesMetadata[]) => { };
 
   return (
     <AssetDocumentsPanel

--- a/src/components/AssetEventsPanel/stories/loadCallback.md
+++ b/src/components/AssetEventsPanel/stories/loadCallback.md
@@ -8,12 +8,12 @@
 import 'antd/dist/antd.css';
 
 import React from 'react';
-import { Event } from '@cognite/sdk';
+import { CogniteEvent } from '@cognite/sdk';
 import { AssetEventsPanel } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
 
-  const handleAssetEventsLoaded = (events: Event[]) => { };
+  const handleAssetEventsLoaded = (events: CogniteEvent[]) => { };
 
   return (
     <AssetEventsPanel

--- a/src/components/AssetMeta/stories/full.md
+++ b/src/components/AssetMeta/stories/full.md
@@ -106,7 +106,7 @@ Definition:
 
 ```typescript
 import { CollapseProps } from 'antd/lib/collapse';
-import { FileMetadata as Document } from '@cognite/sdk/dist/src/types/types';
+import { FilesMetadata as Document } from '@cognite/sdk';
 
 interface MetaDocProps {
   handleDocumentClick?: OnDocumentClick;

--- a/src/components/AssetMeta/stories/selectedDocument.md
+++ b/src/components/AssetMeta/stories/selectedDocument.md
@@ -9,12 +9,12 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { AssetMeta } from '@cognite/gearbox';
-import { File as Document } from '@cognite/sdk';
+import { FilesMetadata } from '@cognite/sdk';
 
 function ExampleComponent(props) {
 
   const handleDocumentClick = (
-    document: Document,
+    document: FilesMetadata,
     category: string,
     description: string
     ) => { };

--- a/src/components/AssetTimeseriesPanel/stories/loadCallback.md
+++ b/src/components/AssetTimeseriesPanel/stories/loadCallback.md
@@ -8,11 +8,11 @@
 import 'antd/dist/antd.css';
 
 import React from 'react';
-import { File } from '@cognite/sdk';
+import { GetTimeSeriesMetadataDTO } from '@cognite/sdk';
 import { AssetTimeseriesPanel } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const handleAssetTimeseriesLoaded = (files: File[]) => {};
+  const handleAssetTimeseriesLoaded = (files: GetTimeSeriesMetadataDTO[]) => {};
   return (
     <AssetTimeseriesPanel
       assetId={4650652196144007}

--- a/src/components/EventPreview/stories/basic.md
+++ b/src/components/EventPreview/stories/basic.md
@@ -8,11 +8,11 @@
 import 'antd/dist/antd.css';
 
 import React from 'react';
-import { Event } from '@cognite/sdk';
+import { CogniteEvent } from '@cognite/sdk/dist/src/types/types';
 import { EventPreview } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const onShowDetails = (event: Event) = {};
+  const onShowDetails = (event: CogniteEvent) = {};
 
   return (
     <EventPreview 

--- a/src/components/EventPreview/stories/full.md
+++ b/src/components/EventPreview/stories/full.md
@@ -15,11 +15,11 @@ shows loading spinner.
 import 'antd/dist/antd.css';
 
 import React from 'react';
-import { Event } from '@cognite/sdk';
+import { CogniteEvent } from '@cognite/sdk/dist/src/types/types';
 import { EventPreview } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const onShowDetails = (event: Event) = {};
+  const onShowDetails = (event: CogniteEvent) = {};
 
   return (
     <EventPreview 
@@ -45,7 +45,7 @@ function ExampleComponent(props) {
 | ------------------- | -------------------------------------------------------------------------- | --------------------------------------------- | ----------- |
 | `hideProperties`    | List of event properties to be hidden. Possible values: `type`, `subtype`, `description`, `startTime`, `endTime`, `metadata`| `Array<keyof Event>`                          | []          |
 | `hideLoadingSpinner`| Defines whether to hide the loading spinner                                | `boolean`                       |             | false       |
-| `onShowDetails`     | Function triggered when user clicks on the 'Explore event details' button. If the function is not provided the button will not be rendered. | `(event: Event) => void`     |             |             |
+| `onShowDetails`     | Function triggered when user clicks on the 'Explore event details' button. If the function is not provided the button will not be rendered. | `(event: CogniteEvent) => void`     |             |             |
 | `strings`           | Object map with strings to customize/localize text in the component        | `{[key: string]: string}`       |             |             |
 | `styles`            | Object that defines inline CSS styles for inner elements of the component. | `EventPreviewStyles`            |             |             |
 
@@ -65,11 +65,11 @@ function ExampleComponent(props) {
 
 ### Types
 
-#### Event
-`Event` type can be imported from @cognite/sdk:
+#### CogniteEvent
+`CogniteEvent` type can be imported from `@cognite/sdk`:
 
 ```typescript
-import { Event } from '@cognite/sdk';
+import { CogniteEvent } from '@cognite/sdk/dist/src/types/types';
 ```
 
 #### EventPreviewStyles

--- a/src/components/EventPreview/stories/hideDateTime.md
+++ b/src/components/EventPreview/stories/hideDateTime.md
@@ -8,11 +8,11 @@
 import 'antd/dist/antd.css';
 
 import React from 'react';
-import { Event } from '@cognite/sdk';
+import { CogniteEvent } from '@cognite/sdk/dist/src/types/types';
 import { EventPreview } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const onShowDetails = (event: Event) = {};
+  const onShowDetails = (event: CogniteEvent) = {};
 
   return (
     <EventPreview 

--- a/src/components/EventPreview/stories/hideDescription.md
+++ b/src/components/EventPreview/stories/hideDescription.md
@@ -8,11 +8,11 @@
 import 'antd/dist/antd.css';
 
 import React from 'react';
-import { Event } from '@cognite/sdk';
+import { CogniteEvent } from '@cognite/sdk/dist/src/types/types';
 import { EventPreview } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const onShowDetails = (event: Event) = {};
+  const onShowDetails = (event: CogniteEvent) = {};
 
   return (
     <EventPreview 

--- a/src/components/EventPreview/stories/hideLoadingSpinner.md
+++ b/src/components/EventPreview/stories/hideLoadingSpinner.md
@@ -8,11 +8,11 @@
 import 'antd/dist/antd.css';
 
 import React from 'react';
-import { Event } from '@cognite/sdk';
+import { CogniteEvent } from '@cognite/sdk/dist/src/types/types';
 import { EventPreview } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const onShowDetails = (event: Event) = {};
+  const onShowDetails = (event: CogniteEvent) = {};
 
   return (
     <EventPreview 

--- a/src/components/EventPreview/stories/hideMetadata.md
+++ b/src/components/EventPreview/stories/hideMetadata.md
@@ -8,11 +8,11 @@
 import 'antd/dist/antd.css';
 
 import React from 'react';
-import { Event } from '@cognite/sdk';
+import { CogniteEvent } from '@cognite/sdk/dist/src/types/types';
 import { EventPreview } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const onShowDetails = (event: Event) = {};
+  const onShowDetails = (event: CogniteEvent) = {};
 
   return (
     <EventPreview 

--- a/src/components/EventPreview/stories/withCustomText.md
+++ b/src/components/EventPreview/stories/withCustomText.md
@@ -8,11 +8,11 @@
 import 'antd/dist/antd.css';
 
 import React from 'react';
-import { Event } from '@cognite/sdk';
+import { CogniteEvent } from '@cognite/sdk/dist/src/types/types';
 import { EventPreview } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
-  const onShowDetails = (event: Event) = {};
+  const onShowDetails = (event: CogniteEvent) = {};
 
   return (
     <EventPreview 

--- a/src/components/SVGViewer/__tests__/SVGViewer.test.tsx
+++ b/src/components/SVGViewer/__tests__/SVGViewer.test.tsx
@@ -1,13 +1,26 @@
+import { API } from '@cognite/sdk-alpha/dist/src/resources/api';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
+import { ClientSDKProvider } from '../../ClientSDKProvider';
 import { SVGViewer } from '../SVGViewer';
 
 configure({ adapter: new Adapter() });
 
+const fakeClient: API = {
+  // @ts-ignore
+  files: {
+    getDownloadUrls: async () => [{ downloadUrl: 'url', id: 123 }],
+  },
+};
+
 describe('SVGViewer', () => {
   it('Renders without exploding', () => {
-    const wrapper = mount(<SVGViewer documentId={0} />);
+    const wrapper = mount(
+      <ClientSDKProvider client={fakeClient}>
+        <SVGViewer documentId={0} />
+      </ClientSDKProvider>
+    );
     expect(wrapper).toHaveLength(1);
   });
 });

--- a/src/components/SensorOverlay/SensorOverlay.tsx
+++ b/src/components/SensorOverlay/SensorOverlay.tsx
@@ -73,6 +73,8 @@ export interface SensorPosition {
   };
 }
 
+export type SensorDatapoint = Datapoint;
+
 export interface SensorMinMaxRange {
   min?: number;
   max?: number;

--- a/src/components/SensorOverlay/stories/full.md
+++ b/src/components/SensorOverlay/stories/full.md
@@ -54,7 +54,7 @@ function ExampleComponent(props) {
 | `isTagDraggable`      | Defines whether it's possible to drag sensor boxes (tags)        | boolean  | true      |
 | `isPointerDraggable`  | Defines whether it's possible to drag sensor pointers            | boolean  | true      |
 | `onClick`             | Function triggered when user clicks on a sensor box or pointer |`(timeserieId: number) => void`    |         |
-| `onLinkClick`         | Function triggered when user clicks on a sensor value link. The link should be enabled with  `linksMap` | `(timeserieId: number, datapoint?: Datapoint) => void`    |         |
+| `onLinkClick`         | Function triggered when user clicks on a sensor value link. The link should be enabled with  `linksMap` | `(timeserieId: number, datapoint?: SensorDatapoint) => void`    |         |
 | `onSettingsClick`     | Function triggered when user clicks on the settings icon. The icon is shown if this prop is defined. | `(timeserieId: number) => void`    |         |
 | `onSensorPositionChange`| Function triggered when either a tag or a pointer has been dragged. | `(timeserieId: number, position: SensorPosition) => void`    |         |
 | `strings`              | Object map with strings to customize/localize text in the component    | `{[key: string]: string}`       |             | 
@@ -100,9 +100,18 @@ interface SensorMinMaxRange {
 }
 ```
 
-#### Datapoint
-This interface is provided by [@cognite/sdk](https://github.com/cognitedata/cognitesdk-js):
+#### SensorDatapoint
+This type can be imported from `@cognite\gearbox`:
 ```typescript
-import { Datapoint } from '@cognite/sdk';
+import { SensorDatapoint } from '@cognite\gearbox';
+```
+
+Definition:
+```typescript
+export interface SensorDatapoint {
+  isString: boolean;
+  value: number | string;
+  timestamp: Date;
+}
 ```
 

--- a/src/components/SensorOverlay/stories/full.md
+++ b/src/components/SensorOverlay/stories/full.md
@@ -101,9 +101,9 @@ interface SensorMinMaxRange {
 ```
 
 #### SensorDatapoint
-This type can be imported from `@cognite\gearbox`:
+This type can be imported from `@cognite/gearbox`:
 ```typescript
-import { SensorDatapoint } from '@cognite\gearbox';
+import { SensorDatapoint } from '@cognite/gearbox';
 ```
 
 Definition:

--- a/src/components/SensorOverlay/stories/withLink.md
+++ b/src/components/SensorOverlay/stories/withLink.md
@@ -8,13 +8,12 @@
 import 'antd/dist/antd.css';
 
 import React from 'react';
-import { SensorOverlay } from '@cognite/gearbox';
-import { Datapoint } from '@cognite/sdk';
+import { SensorOverlay, SensorDatapoint } from '@cognite/gearbox';
 
 function ExampleComponent(props) {
   const timeseriesIds = [8681821313339919];
   const handleClick = (timeserieId: number) => {};
-  const handleLinkClick = (timeserieId: number, datapoint: Datapoint) => {};
+  const handleLinkClick = (timeserieId: number, datapoint: SensorDatapoint) => {};
 
   return (
     <SensorOverlay

--- a/src/components/ThemeProvider/stories/ThemeProvider.stories.tsx
+++ b/src/components/ThemeProvider/stories/ThemeProvider.stories.tsx
@@ -1,9 +1,8 @@
-import * as sdk from '@cognite/sdk';
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import React from 'react';
 
-import { EVENTS } from '../../../mocks';
+import { fakeEvents } from '../../../mocks';
 import { AssetTree } from '../../AssetTree';
 import { fakeClient } from '../../AssetTree/stories/AssetTree.stories';
 import { ClientSDKProvider } from '../../ClientSDKProvider';
@@ -98,7 +97,10 @@ storiesOf('ThemeProvider/Examples', module)
   .add(
     'Event Preview',
     () => {
-      sdk.Events.retrieve = () => Promise.resolve(EVENTS[0]);
+      // @ts-ignore
+      fakeClient.events = {
+        retrieve: () => Promise.resolve([fakeEvents[0]]),
+      };
       return (
         <ThemeProvider
           theme={{

--- a/src/components/TimeseriesChart/stories/TimeseriesChart.stories.tsx
+++ b/src/components/TimeseriesChart/stories/TimeseriesChart.stories.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable react/no-multi-comp */
 import { AxisDisplayMode } from '@cognite/griff-react';
-import * as sdk from '@cognite/sdk';
 import { API } from '@cognite/sdk-alpha/dist/src/resources/api';
 import {
   DatapointsGetAggregateDatapoint,
@@ -40,30 +39,7 @@ import startEnd from './startEnd.md';
 import xAxisHeight from './xAxisHeight.md';
 import zoomable from './zoomable.md';
 
-const randomData = (start: number, end: number, n: number): sdk.Datapoint[] => {
-  const data = [];
-  const dt = (end - start) / n;
-  for (let i = start; i <= end; i += dt) {
-    const values = [0, 0, 0]
-      .map(
-        () =>
-          Math.sin(i / 20) * 50 +
-          Math.cos(Math.PI - i / 40) * 50 +
-          Math.random() * 40
-      )
-      .sort((a: number, b: number) => a - b);
-    data.push({
-      timestamp: i,
-      average: values[1],
-      min: values[0],
-      max: values[2],
-      count: 7000,
-    });
-  }
-  return data;
-};
-
-const randomData2 = (
+const randomData = (
   start: number,
   end: number,
   n: number
@@ -114,7 +90,7 @@ export const fakeClient: API = {
       action('client.datapoints.retrieve')(query);
       return new Promise(resolve => {
         setTimeout(() => {
-          const result = randomData2(
+          const result = randomData(
             (query.items[0].start && +query.items[0].start) || 0,
             (query.items[0].end && +query.items[0].end) || 0,
             100
@@ -155,7 +131,7 @@ const fakeZoomableClient: API = {
           const granularity = query.items[0].granularity || '10s';
           const n =
             granularity === 's' ? 2 : granularity.includes('s') ? 10 : 250;
-          const result = randomData2(
+          const result = randomData(
             (query.items[0].start && +query.items[0].start) || 0,
             (query.items[0].end && +query.items[0].end) || 100,
             n

--- a/src/components/TimeseriesChartMeta/components/TimeseriesMetaInfo.test.tsx
+++ b/src/components/TimeseriesChartMeta/components/TimeseriesMetaInfo.test.tsx
@@ -1,4 +1,3 @@
-import * as sdk from '@cognite/sdk';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
@@ -6,8 +5,6 @@ import { timeseriesListV2 } from '../../../mocks';
 import { TimeseriesMetaInfo } from './TimeseriesMetaInfo';
 
 configure({ adapter: new Adapter() });
-
-sdk.Datapoints.retrieveLatest = jest.fn();
 
 const timeseries = timeseriesListV2[0];
 

--- a/src/components/TimeseriesSearch/TimeseriesSearch.test.tsx
+++ b/src/components/TimeseriesSearch/TimeseriesSearch.test.tsx
@@ -1,4 +1,3 @@
-import * as sdk from '@cognite/sdk';
 import { API } from '@cognite/sdk-alpha/dist/src/resources/api';
 import { Button, Input, Tag } from 'antd';
 import { configure, mount } from 'enzyme';
@@ -31,16 +30,11 @@ const mockedClient: API = {
   },
 };
 
-// @ts-ignore
-sdk.Assets.list = jest.fn();
-
 beforeEach(() => {
   // @ts-ignore
   mockedClient.timeseries.retrieve.mockResolvedValue(timeseriesListV2);
   // @ts-ignore
   mockedClient.timeseries.search.mockResolvedValue(timeseriesListV2);
-  // @ts-ignore
-  sdk.Assets.list.mockResolvedValue({ items: assetsList });
 });
 
 afterEach(() => {

--- a/src/components/TimeseriesSearch/stories/allowStrings.md
+++ b/src/components/TimeseriesSearch/stories/allowStrings.md
@@ -12,9 +12,9 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { TimeseriesSearch } from '@cognite/gearbox';
-import { Timeseries} from '@cognite/sdk';
+import { GetTimeSeriesMetadataDTO } from '@cognite/sdk/dist/src/types/types';
 
-const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: Timeseries) => {}
+const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: GetTimeSeriesMetadataDTO) => {}
 function ExampleComponent(props) {
   return (
     <TimeseriesSearch

--- a/src/components/TimeseriesSearch/stories/basic.md
+++ b/src/components/TimeseriesSearch/stories/basic.md
@@ -12,9 +12,9 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { TimeseriesSearch } from '@cognite/gearbox';
-import { Timeseries} from '@cognite/sdk';
+import { GetTimeSeriesMetadataDTO } from '@cognite/sdk/dist/src/types/types';
 
-const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: Timeseries) => {}
+const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: GetTimeSeriesMetadataDTO) => {}
 function ExampleComponent(props) {
   return (
     <TimeseriesSearch

--- a/src/components/TimeseriesSearch/stories/customFilter.md
+++ b/src/components/TimeseriesSearch/stories/customFilter.md
@@ -12,9 +12,9 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { TimeseriesSearch } from '@cognite/gearbox';
-import { Timeseries} from '@cognite/sdk';
+import { GetTimeSeriesMetadataDTO } from '@cognite/sdk/dist/src/types/types';
 
-const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: Timeseries) => {}
+const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: GetTimeSeriesMetadataDTO) => {}
 const filterRule = (timeseries: Timeseries) =>  !timeseries.isString;
 function ExampleComponent(props) {
   return (

--- a/src/components/TimeseriesSearch/stories/customStrings.md
+++ b/src/components/TimeseriesSearch/stories/customStrings.md
@@ -12,9 +12,9 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { TimeseriesSearch } from '@cognite/gearbox';
-import { Timeseries} from '@cognite/sdk';
+import { GetTimeSeriesMetadataDTO } from '@cognite/sdk/dist/src/types/types';
 
-const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: Timeseries) => {}
+const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: GetTimeSeriesMetadataDTO) => {}
 function ExampleComponent(props) {
   return (
     <TimeseriesSearch

--- a/src/components/TimeseriesSearch/stories/customStyles.md
+++ b/src/components/TimeseriesSearch/stories/customStyles.md
@@ -12,9 +12,9 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { TimeseriesSearch } from '@cognite/gearbox';
-import { Timeseries} from '@cognite/sdk';
+import { GetTimeSeriesMetadataDTO } from '@cognite/sdk/dist/src/types/types';
 
-const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: Timeseries) => {}
+const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: GetTimeSeriesMetadataDTO) => {}
 function ExampleComponent(props) {
   return (
     <TimeseriesSearch

--- a/src/components/TimeseriesSearch/stories/full.md
+++ b/src/components/TimeseriesSearch/stories/full.md
@@ -14,9 +14,9 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { TimeseriesSearch } from '@cognite/gearbox';
-import { Timeseries} from '@cognite/sdk';
+import { GetTimeSeriesMetadataDTO } from '@cognite/sdk/dist/src/types/types';
 
-const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: Timeseries) => {}
+const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: GetTimeSeriesMetadataDTO) => {}
 function ExampleComponent(props) {
   return (
     <TimeseriesSearch
@@ -47,16 +47,16 @@ You can search for `${names}`
 | `single`             | Removes the checkboxes from search result and will only callback with one id | `boolean`                                 | `false`     |
 | `hideSelected`       | Hides the row with selected timeseries above the search bar                  | `boolean`                                 | `false`     |
 | `allowStrings`       | Allows the user to select search results that are strings                    | `boolean`                                 | `false`     |
-| `filterRule`         | Custom rule to filter search results                                         | `(timeseries: Timeseries) => boolean`     |             |
+| `filterRule`         | Custom rule to filter search results                                         | `(timeseries: GetTimeSeriesMetadataDTO) => boolean`     |             |
 | `onError`            | Function called on fetch timeseries error                                    | `(error: Error) => void`                  |             |
 | `styles`             | Custom styles for the component                                              | `TimeseriesSearchStyles`                  |             |
 
 ### Types
 
-### Timeseries
+### GetTimeSeriesMetadataDTO
 
 This type describes what the cognite API returns when fetching timeseries.
-It can be imported from `@cognite/sdk`.
+It can be imported from `@cognite/sdk/dist/src/types/types`.
 Documentation can be found at https://js-sdk-docs.cogniteapp.com/interfaces/timeseries.html.
 
 ### TimeseriesSearchStyles

--- a/src/components/TimeseriesSearch/stories/hideSelectedRow.md
+++ b/src/components/TimeseriesSearch/stories/hideSelectedRow.md
@@ -12,9 +12,9 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { TimeseriesSearch } from '@cognite/gearbox';
-import { Timeseries} from '@cognite/sdk';
+import { GetTimeSeriesMetadataDTO } from '@cognite/sdk/dist/src/types/types';
 
-const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: Timeseries) => {}
+const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: GetTimeSeriesMetadataDTO) => {}
 function ExampleComponent(props) {
   return (
     <TimeseriesSearch

--- a/src/components/TimeseriesSearch/stories/preselected.md
+++ b/src/components/TimeseriesSearch/stories/preselected.md
@@ -12,9 +12,9 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { TimeseriesSearch } from '@cognite/gearbox';
-import { Timeseries} from '@cognite/sdk';
+import { GetTimeSeriesMetadataDTO } from '@cognite/sdk/dist/src/types/types';
 
-const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: Timeseries) => {}
+const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: GetTimeSeriesMetadataDTO) => {}
 function ExampleComponent(props) {
   return (
     <TimeseriesSearch

--- a/src/components/TimeseriesSearch/stories/rootAssetSelect.md
+++ b/src/components/TimeseriesSearch/stories/rootAssetSelect.md
@@ -12,9 +12,9 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { TimeseriesSearch } from '@cognite/gearbox';
-import { Timeseries} from '@cognite/sdk';
+import { GetTimeSeriesMetadataDTO } from '@cognite/sdk/dist/src/types/types';
 
-const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: Timeseries) => {}
+const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: GetTimeSeriesMetadataDTO) => {}
 function ExampleComponent(props) {
   return (
     <TimeseriesSearch

--- a/src/components/TimeseriesSearch/stories/singleSelection.md
+++ b/src/components/TimeseriesSearch/stories/singleSelection.md
@@ -12,9 +12,9 @@ import 'antd/dist/antd.css';
 
 import React from 'react';
 import { TimeseriesSearch } from '@cognite/gearbox';
-import { Timeseries} from '@cognite/sdk';
+import { GetTimeSeriesMetadataDTO } from '@cognite/sdk/dist/src/types/types';
 
-const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: Timeseries) => {}
+const onTimeserieSelectionChange = (newTimeseriesIds: number[], selectedTimeseries: GetTimeSeriesMetadataDTO) => {}
 function ExampleComponent(props) {
   return (
     <TimeseriesSearch

--- a/src/mocks/assetsList.ts
+++ b/src/mocks/assetsList.ts
@@ -1,4 +1,4 @@
-import { Asset } from '@cognite/sdk';
+import { Asset } from '@cognite/sdk-alpha/dist/src/types/types';
 import { AdvancedSearch } from '../interfaces';
 
 export const vmateDba = 'wmate_dba.wmt_location';
@@ -30,6 +30,9 @@ export const SKA: Asset = {
     WMT_LOCATION_USEPLOTALTITUDE: 'Y',
     WMT_LOCATION_WORKSTART: randomTime,
   },
+  createdTime: new Date(1),
+  lastUpdatedTime: new Date(2),
+  depth: 1,
 };
 
 export const IAA: Asset = {
@@ -49,6 +52,9 @@ export const IAA: Asset = {
     TYPE: 'AssetHierarchy',
     UID: 'IAA',
   },
+  createdTime: new Date(1),
+  lastUpdatedTime: new Date(2),
+  depth: 1,
 };
 
 export const VAL: Asset = {
@@ -75,6 +81,9 @@ export const VAL: Asset = {
     WMT_LOCATION_USEPLOTALTITUDE: 'Y',
     WMT_LOCATION_WORKSTART: randomTime,
   },
+  createdTime: new Date(1),
+  lastUpdatedTime: new Date(2),
+  depth: 1,
 };
 
 export const SearchValue: AdvancedSearch = {

--- a/src/mocks/events.ts
+++ b/src/mocks/events.ts
@@ -1,5 +1,4 @@
 /* tslint:disable:no-duplicate-string */
-import { Event as ApiEvent } from '@cognite/sdk';
 import { CogniteEvent } from '@cognite/sdk-alpha/dist/src/types/types';
 import moment from 'moment-timezone';
 import { AssetMetaStyles } from '../components/AssetMeta';
@@ -115,106 +114,6 @@ export const ASSET_META_STYLES: AssetMetaStyles = {
   documents: ASSET_META_DOCS_STYLES,
   events: ASSET_META_EVENTS_STYLES,
 };
-
-export const EVENTS: ApiEvent[] = [
-  {
-    id: 1995162693488,
-    type: 'failure',
-    subtype: 'Valhall',
-    metadata: {
-      source: 'akerbp-cdp1',
-      sourceId: '8357488757942266',
-    },
-    description: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-    startTime: baseTimestamp,
-    assetIds: [4650652196144007],
-    source: 'akerbp-cdpr',
-    sourceId: '8357488757942266',
-    createdTime: 1538252247102,
-    lastUpdatedTime: 1538252247102,
-  },
-  {
-    id: 8825861064387,
-    type: 'alert',
-    subtype: 'Val',
-    metadata: {
-      source: 'akerbp-cdp9',
-      sourceId: '5712479887811020',
-    },
-    description:
-      'sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.' +
-      'Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris' +
-      ' nisi ut aliquip ex ea commodo consequat.',
-    startTime: baseTimestamp + 3 * 24 * 60 * 60 * 1000,
-    endTime: baseTimestamp + 6 * 24 * 60 * 60 * 1000,
-    assetIds: [4650652196144007],
-    source: 'akerbp-cdp',
-    sourceId: '5712479887811020',
-    createdTime: 1544644816746,
-    lastUpdatedTime: 1544644816746,
-  },
-  {
-    id: 25496029326330,
-    type: 'workorder',
-    subtype: 'Val',
-    metadata: {
-      source: 'akerbp-cdp5',
-      sourceId: '2045316963854017',
-    },
-    description:
-      'Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.',
-    startTime: baseTimestamp + 13 * 24 * 60 * 60 * 1000,
-    endTime: baseTimestamp + 20 * 24 * 60 * 60 * 1000,
-    assetIds: [4650652196144007],
-    source: 'akerbp-cdp',
-    sourceId: '2045316963854017',
-    createdTime: 1548932470085,
-    lastUpdatedTime: 1548932470085,
-  },
-  {
-    id: 33766051546406,
-    type: 'failure',
-    subtype: 'Val',
-    metadata: {
-      source: 'akerbp-cdp2',
-      sourceId: '6122324097482222',
-    },
-    description: 'Excepteur sint occaecat cupidatat non proident',
-    startTime: baseTimestamp - 20 * 24 * 60 * 60 * 1000,
-    endTime: baseTimestamp - 10 * 24 * 60 * 60 * 1000,
-    assetIds: [4650652196144007],
-    source: 'akerbp-cdp',
-    sourceId: '6122324097482222',
-    createdTime: 1548273625540,
-    lastUpdatedTime: 1548273625540,
-  },
-  {
-    id: 35593709738144,
-    type: 'alert',
-    subtype: 'Val',
-    metadata: {
-      source: 'akerbp-cdp4',
-      sourceId: '3080723126388384',
-    },
-    description:
-      'Sunt in culpa qui officia deserunt mollit anim id est laborum.',
-    startTime: baseTimestamp + 43 * 24 * 60 * 60 * 1000,
-    endTime: baseTimestamp + 50 * 24 * 60 * 60 * 1000,
-    assetIds: [4650652196144007],
-    source: 'akerbp-cdp3',
-    sourceId: '3080723126388384',
-    createdTime: 1548932461186,
-    lastUpdatedTime: 1548932461186,
-  },
-  {
-    id: 35593709738145,
-    assetIds: [4650652196144007],
-    source: 'akerbp-cdp3',
-    sourceId: '3080723126388384',
-    createdTime: 1548932461186,
-    lastUpdatedTime: 1548932461186,
-  },
-];
 
 export const fakeEvents: CogniteEvent[] = [
   {

--- a/src/mocks/timeseriesDataPointsList.ts
+++ b/src/mocks/timeseriesDataPointsList.ts
@@ -1,6 +1,4 @@
-import { DataDatapoints, Datapoint } from '@cognite/sdk';
-
-export const datapoints: Datapoint[] = [
+export const datapoints = [
   {
     timestamp: 1552726800000,
     average: 36.26105251209135,
@@ -920,7 +918,7 @@ export const datapoints: Datapoint[] = [
   },
 ];
 
-export const datapointsList: DataDatapoints = {
+export const datapointsList = {
   name: 'abc',
   datapoints,
 };

--- a/src/utils/tests/utils.test.ts
+++ b/src/utils/tests/utils.test.ts
@@ -1,3 +1,4 @@
+import { Asset } from '@cognite/sdk-alpha/dist/src/types/types';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import {
@@ -59,7 +60,9 @@ describe('utils', () => {
     `(
       'Filters responce strings length from 5 to 20 chars and with custom from $minLen to $maxLen',
       ({ minLen, maxLen, expected }) => {
-        expect(extractValidStrings(arr, maxLen, minLen)).toEqual(expected);
+        expect(
+          extractValidStrings((arr as any) as Asset[], maxLen, minLen)
+        ).toEqual(expected);
       }
     );
   });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,4 @@
-import { Asset } from '@cognite/sdk';
+import { Asset } from '@cognite/sdk-alpha/dist/src/types/types';
 
 export function clampNumber(v: number, minValue: number, maxValue: number) {
   return Math.max(Math.min(v, maxValue), minValue);


### PR DESCRIPTION
Clean out of old SDK.
Documentation updated with new SDK types.
Removed unused functions in `api.ts`