### PR TITLE
Joyrostie/sdk2.0 asset search issue#360

### DIFF
--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -146,10 +146,9 @@ export class AssetSearch extends React.Component<
             metadata:
               (query.advancedSearch &&
                 query.advancedSearch.metadata &&
-                query.advancedSearch.metadata.reduce(
-                  (a, c) => ({ ...a, [c.key]: c.value }),
-                  {}
-                )) ||
+                query.advancedSearch.metadata
+                  .filter(meta => meta.key !== '')
+                  .reduce((a, c) => ({ ...a, [c.key]: c.value }), {})) ||
               undefined,
           },
       search: {

--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -146,9 +146,10 @@ export class AssetSearch extends React.Component<
             metadata:
               (query.advancedSearch &&
                 query.advancedSearch.metadata &&
-                query.advancedSearch.metadata
-                  .filter(meta => meta.key !== '')
-                  .reduce((a, c) => ({ ...a, [c.key]: c.value }), {})) ||
+                query.advancedSearch.metadata.reduce(
+                  (a, c) => (c.key ? { ...a, [c.key]: c.value } : a),
+                  {}
+                )) ||
               undefined,
           },
       search: {

--- a/src/components/common/Search/Search.tsx
+++ b/src/components/common/Search/Search.tsx
@@ -145,11 +145,7 @@ export class Search extends React.Component<SearchProps, SearchState> {
       showLiveSearchResults,
       liveSearchResults: propsSearchResults,
     } = props;
-    const {
-      liveSearchResults: stateSearchResults,
-      query,
-      advancedSearchQuery,
-    } = state;
+    const { liveSearchResults: stateSearchResults, query } = state;
 
     if (!showLiveSearchResults) {
       return null;
@@ -158,7 +154,7 @@ export class Search extends React.Component<SearchProps, SearchState> {
     if (propsSearchResults !== stateSearchResults) {
       return {
         liveSearchResults: propsSearchResults,
-        liveSearchShow: !!query || !!advancedSearchQuery,
+        liveSearchShow: !!query,
       };
     }
 


### PR DESCRIPTION
* Updated `AssetSearch` sdk query with empty Metadata object.
* Fixed `Search` showing live search results with advanced search prop.

SDK2.0 Components

Closes #360 