### PR TITLE
Frikkfossan/assetscanner crop image

### DIFF
--- a/src/components/AssetScanner/AssetScanner.tsx
+++ b/src/components/AssetScanner/AssetScanner.tsx
@@ -74,6 +74,7 @@ export interface AssetScannerProps {
   onOcrError?: Callback;
   onError?: Callback;
   onImageReset?: Callback;
+  imageAltText?: string;
   styles?: AssetScannerStyles;
   strings?: PureObject;
   cropSize?: CropSize;
@@ -233,6 +234,7 @@ export class AssetScanner extends React.Component<
       button,
       cropSize,
       webcamCropOverlay,
+      imageAltText,
     } = this.props;
 
     return (
@@ -240,6 +242,7 @@ export class AssetScanner extends React.Component<
         <WebcamScanner
           isLoading={isLoading}
           imageSrc={imageSrc}
+          imageAltText={imageAltText}
           capture={this.captureBound}
           setRef={this.setRefBound}
           onReset={this.resetSearchBound}

--- a/src/components/AssetScanner/AssetScanner.tsx
+++ b/src/components/AssetScanner/AssetScanner.tsx
@@ -202,7 +202,6 @@ export class AssetScanner extends React.Component<
   }
 
   async capture() {
-    console.log('Capturing');
     this.startLoading();
     await this.setReady(false);
 
@@ -331,7 +330,6 @@ export class AssetScanner extends React.Component<
         this.video.videoHeight;
     }
 
-    console.log(' CH:', clientHeight, 'CW: ', clientWidth);
     const cropSizeAdjusted = cropSize
       ? {
           height: (cropSize.height * this.video.videoHeight) / clientHeight,

--- a/src/components/AssetScanner/AssetScanner.tsx
+++ b/src/components/AssetScanner/AssetScanner.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { getAssetList, ocrRecognize } from '../../api';
 import {
   Callback,
+  CropSize,
   EmptyCallback,
   OcrRequest,
   OnAssetListCallback,
@@ -21,7 +22,6 @@ import {
   ocrSuccess,
 } from '../../utils/notifications';
 import {
-  CropSize,
   getCanvas,
   removeImageBase,
   scaleCropSizeToVideoResolution,
@@ -312,10 +312,11 @@ export class AssetScanner extends React.Component<
 
   private getImage(): Promise<string> {
     const { imageSrc } = this.state;
+    const { cropSize } = this.props;
 
     return imageSrc
       ? Promise.resolve(imageSrc)
-      : this.getImageFromCanvas(this.props.cropSize);
+      : this.getImageFromCanvas(cropSize);
   }
 
   // Made async to provide better UX for component

--- a/src/components/AssetScanner/AssetScanner.tsx
+++ b/src/components/AssetScanner/AssetScanner.tsx
@@ -20,7 +20,7 @@ import {
   ocrNoTextFound,
   ocrSuccess,
 } from '../../utils/notifications';
-import { getCanvas, removeImageBase } from '../../utils/utils';
+import { CropSize, getCanvas, removeImageBase } from '../../utils/utils';
 import { WebcamScanner } from './WebcamScanner/WebcamScanner';
 
 const Wrapper = styled.div`
@@ -70,6 +70,7 @@ export interface AssetScannerProps {
   onImageReset?: Callback;
   styles?: AssetScannerStyles;
   strings?: PureObject;
+  cropSize?: CropSize;
 }
 
 interface AssetScannerState {
@@ -201,6 +202,7 @@ export class AssetScanner extends React.Component<
   }
 
   async capture() {
+    console.log('Capturing');
     this.startLoading();
     await this.setReady(false);
 
@@ -218,7 +220,7 @@ export class AssetScanner extends React.Component<
 
   render() {
     const { isLoading, imageSrc, ready } = this.state;
-    const { styles, strings, onError, button } = this.props;
+    const { styles, strings, onError, button, cropSize } = this.props;
 
     return (
       <Wrapper>
@@ -233,6 +235,7 @@ export class AssetScanner extends React.Component<
           onError={onError}
           button={button}
           isReady={ready}
+          cropSize={cropSize}
         />
       </Wrapper>
     );
@@ -296,11 +299,13 @@ export class AssetScanner extends React.Component<
   private getImage(): Promise<string> {
     const { imageSrc } = this.state;
 
-    return imageSrc ? Promise.resolve(imageSrc) : this.getImageFromCanvas();
+    return imageSrc
+      ? Promise.resolve(imageSrc)
+      : this.getImageFromCanvas(this.props.cropSize);
   }
 
   // Made async to provide better UX for component
-  private getImageFromCanvas(): Promise<string> {
+  private getImageFromCanvas(cropSize?: CropSize): Promise<string> {
     const { errorVideoAccess } = ASNotifyTypes;
 
     if (!this.video) {
@@ -313,7 +318,8 @@ export class AssetScanner extends React.Component<
     const canvas = getCanvas(
       this.video,
       this.video.clientWidth,
-      this.video.clientWidth / aspectRatio
+      this.video.clientWidth / aspectRatio,
+      cropSize
     );
 
     return new Promise(resolve =>

--- a/src/components/AssetScanner/AssetScanner.tsx
+++ b/src/components/AssetScanner/AssetScanner.tsx
@@ -304,6 +304,11 @@ export class AssetScanner extends React.Component<
       : this.getImageFromCanvas(this.props.cropSize);
   }
 
+  private isCameraHorizontal = (video: HTMLVideoElement) => {
+    const { videoHeight, videoWidth } = video;
+    return videoWidth / videoHeight >= 1;
+  };
+
   // Made async to provide better UX for component
   private getImageFromCanvas(cropSize?: CropSize): Promise<string> {
     const { errorVideoAccess } = ASNotifyTypes;
@@ -313,13 +318,31 @@ export class AssetScanner extends React.Component<
 
       return Promise.resolve('');
     }
+    const horizontal = this.isCameraHorizontal(this.video);
+    let clientHeight = this.video.clientHeight;
+    let clientWidth = this.video.clientWidth;
+    if (horizontal) {
+      clientHeight =
+        (this.video.clientWidth * this.video.videoHeight) /
+        this.video.videoWidth;
+    } else {
+      clientWidth =
+        (this.video.videoWidth * this.video.clientHeight) /
+        this.video.videoHeight;
+    }
 
-    const aspectRatio = this.video.videoWidth / this.video.videoHeight;
+    console.log(' CH:', clientHeight, 'CW: ', clientWidth);
+    const cropSizeAdjusted = cropSize
+      ? {
+          height: (cropSize.height * this.video.videoHeight) / clientHeight,
+          width: (cropSize.width * this.video.videoWidth) / clientWidth,
+        }
+      : cropSize;
     const canvas = getCanvas(
       this.video,
-      this.video.clientWidth,
-      this.video.clientWidth / aspectRatio,
-      cropSize
+      this.video.videoWidth,
+      this.video.videoHeight,
+      cropSizeAdjusted
     );
 
     return new Promise(resolve =>

--- a/src/components/AssetScanner/AssetScanner.tsx
+++ b/src/components/AssetScanner/AssetScanner.tsx
@@ -77,6 +77,7 @@ export interface AssetScannerProps {
   styles?: AssetScannerStyles;
   strings?: PureObject;
   cropSize?: CropSize;
+  webcamCropOverlay?: React.ComponentType;
 }
 
 interface AssetScannerState {
@@ -225,7 +226,14 @@ export class AssetScanner extends React.Component<
 
   render() {
     const { isLoading, imageSrc, ready } = this.state;
-    const { styles, strings, onError, button, cropSize } = this.props;
+    const {
+      styles,
+      strings,
+      onError,
+      button,
+      cropSize,
+      webcamCropOverlay,
+    } = this.props;
 
     return (
       <Wrapper>
@@ -241,6 +249,7 @@ export class AssetScanner extends React.Component<
           button={button}
           isReady={ready}
           cropSize={cropSize}
+          webcamCropOverlay={webcamCropOverlay}
         />
       </Wrapper>
     );

--- a/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.test.tsx
+++ b/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.test.tsx
@@ -1,0 +1,21 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import {
+  WebcamCropPlaceholder,
+  WebcamCropPlaceholderProps,
+} from './WebcamCropPlaceholder';
+
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+configure({ adapter: new Adapter() });
+
+describe('WebcampCropPlaceholder', () => {
+  it('Should render without exploding, and find the cropper-placeholder element', () => {
+    const props: WebcamCropPlaceholderProps = { height: 200, width: 400 };
+    const wrapper = mount(<WebcamCropPlaceholder {...props} />);
+    expect(
+      wrapper.find('[data-test-id="cropper-placeholder"]').hostNodes()
+    ).toHaveLength(1);
+  });
+});

--- a/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
+++ b/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
@@ -31,7 +31,7 @@ export const WebcamCropPlaceholder = (props: WebcamCropPlaceholderProps) => {
       <Item />
       <Item />
       <Item />
-      <CropperPlaceholder />
+      <CropperPlaceholder data-test-id="cropper-placeholder" />
       <Item />
       <Item />
       <Item />

--- a/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
+++ b/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 export interface WebcamCropPlaceholderProps {
   height: number;
   width: number;
+  backgroundColor?: string;
+  Component?: React.ComponentType;
 }
 
 const Container = styled.div`
@@ -11,31 +13,51 @@ const Container = styled.div`
   height: 100%;
   width: 100%;
   display: grid;
-  grid-template-columns: auto ${(props: WebcamCropPlaceholderProps) =>
-      props.width}px auto;
-  grid-template-rows: auto ${(props: WebcamCropPlaceholderProps) =>
-      props.height}px auto;
+  grid-template-columns: auto ${({ width }: WebcamCropPlaceholderProps) =>
+      width}px auto;
+  grid-template-rows: auto ${({ height }: WebcamCropPlaceholderProps) =>
+      height}px auto;
 `;
 
 const Item = styled.div`
-  background-color: rgba(0, 0, 0, 0.6);
+  background-color: ${({ backgroundColor }: WebcamCropPlaceholderProps) =>
+    backgroundColor ? backgroundColor : 'rgba(0,0,0,0.8)'};
   color: #fff;
 `;
 
-const CropperPlaceholder = styled.div``;
+const CropperPlaceholder = styled.div`
+  z-index: 1;
+`;
+
+const CustomClientOverlayWrapper = styled.div`
+  position: absolute;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+`;
 
 export const WebcamCropPlaceholder = (props: WebcamCropPlaceholderProps) => {
+  const { Component } = props;
   return (
-    <Container {...props}>
-      <Item />
-      <Item />
-      <Item />
-      <Item />
-      <CropperPlaceholder data-test-id="cropper-placeholder" />
-      <Item />
-      <Item />
-      <Item />
-      <Item />
-    </Container>
+    <>
+      <Container {...props}>
+        <Item {...props} />
+        <Item {...props} />
+        <Item {...props} />
+        <Item {...props} />
+        <CropperPlaceholder data-test-id="cropper-placeholder" />
+        <Item {...props} />
+        <Item {...props} />
+        <Item {...props} />
+        <Item {...props} />
+      </Container>
+      {Component && (
+        <CustomClientOverlayWrapper>
+          <Component />
+        </CustomClientOverlayWrapper>
+      )}
+    </>
   );
 };

--- a/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
+++ b/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
@@ -1,60 +1,41 @@
 import React from 'react';
-import { getMiddlePixelsOfContainer } from '../../../utils/utils';
+import styled from 'styled-components';
 
 export interface WebcamCropPlaceholderProps {
   height: number;
   width: number;
 }
 
+const Container = styled.div`
+  position: absolute;
+  height: 100%;
+  width: 100%;
+  display: grid;
+  grid-template-columns: auto ${(props: WebcamCropPlaceholderProps) =>
+      props.width}px auto;
+  grid-template-rows: auto ${(props: WebcamCropPlaceholderProps) =>
+      props.height}px auto;
+`;
+
+const Item = styled.div`
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+`;
+
+const CropperPlaceholder = styled.div``;
+
 export const WebcamCropPlaceholder = (props: WebcamCropPlaceholderProps) => {
-  const { width, height } = props;
-
-  const canvasRef = React.useRef(null);
-  const rootDivRef = React.useRef(null);
-
-  const drawCanvas = (
-    canvasRef: any,
-    width: number,
-    height: number,
-    parentWidth: number,
-    parentHeight: number
-  ) => {
-    const { sx, sy, dx, dy } = getMiddlePixelsOfContainer(
-      width,
-      height,
-      parentWidth,
-      parentHeight
-    );
-    console.log(sx, sy, dx, dy, width, height, parentHeight, parentWidth);
-    const canvas = canvasRef.current;
-    canvas.style.width = '100%';
-    canvas.style.height = '100%';
-    canvas.fillStyle = 'rgba(0,0,0,0.4)';
-    canvas.width = parentWidth;
-    canvas.height = parentHeight;
-    const ctx = canvas.getContext('2d');
-    ctx.fillRect(0, 0, parentWidth, parentHeight);
-    ctx.clearRect(sx, sy, dx, dy);
-    ctx.save();
-  };
-
-  React.useEffect(() => {
-    console.log('Drawing canvas');
-    const divHeight = rootDivRef ? rootDivRef.current.offsetHeight : 0;
-    const divWidth = rootDivRef ? rootDivRef.current.clientWidth : 0;
-    drawCanvas(canvasRef, width, height, divWidth, divHeight);
-  }, []);
-
   return (
-    <div
-      ref={rootDivRef}
-      style={{
-        position: 'absolute',
-        width: '100%',
-        height: '100%',
-      }}
-    >
-      <canvas ref={canvasRef} />
-    </div>
+    <Container {...props}>
+      <Item />
+      <Item />
+      <Item />
+      <Item />
+      <CropperPlaceholder />
+      <Item />
+      <Item />
+      <Item />
+      <Item />
+    </Container>
   );
 };

--- a/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
+++ b/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import { getMiddlePixelsOfContainer } from '../../../utils/utils';
+
+export interface WebcamCropPlaceholderProps {
+  height: number;
+  width: number;
+}
+
+export const WebcamCropPlaceholder = (props: WebcamCropPlaceholderProps) => {
+  const { width, height } = props;
+
+  const canvasRef = React.useRef(null);
+  const rootDivRef = React.useRef(null);
+
+  const drawCanvas = (
+    canvasRef: any,
+    width: number,
+    height: number,
+    parentWidth: number,
+    parentHeight: number
+  ) => {
+    const { sx, sy, dx, dy } = getMiddlePixelsOfContainer(
+      width,
+      height,
+      parentWidth,
+      parentHeight
+    );
+    console.log(sx, sy, dx, dy, width, height, parentHeight, parentWidth);
+    const canvas = canvasRef.current;
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+    canvas.fillStyle = 'rgba(0,0,0,0.4)';
+    canvas.width = parentWidth;
+    canvas.height = parentHeight;
+    const ctx = canvas.getContext('2d');
+    ctx.fillRect(0, 0, parentWidth, parentHeight);
+    ctx.clearRect(sx, sy, dx, dy);
+    ctx.save();
+  };
+
+  React.useEffect(() => {
+    console.log('Drawing canvas');
+    const divHeight = rootDivRef ? rootDivRef.current.offsetHeight : 0;
+    const divWidth = rootDivRef ? rootDivRef.current.clientWidth : 0;
+    drawCanvas(canvasRef, width, height, divWidth, divHeight);
+  }, []);
+
+  return (
+    <div
+      ref={rootDivRef}
+      style={{
+        position: 'absolute',
+        width: '100%',
+        height: '100%',
+      }}
+    >
+      <canvas ref={canvasRef} />
+    </div>
+  );
+};

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.test.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.test.tsx
@@ -27,7 +27,9 @@ describe('WebcamScanner', () => {
         cropSize: { height: 400, width: 200 },
       };
       const wrapper = mount(<WebcamScanner {...props} />);
-      expect(wrapper.find(cropPlaceholderSelector).hostNodes()).toHaveLength(1);
+      expect(
+        wrapper.find(cropPlaceholderSelector).hostNodes().length
+      ).toBeGreaterThanOrEqual(1);
     });
 
     it('Should not render crop placeholder', () => {

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.test.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.test.tsx
@@ -19,33 +19,30 @@ describe('WebcamScanner', () => {
     expect(wrapper).toBeDefined();
   });
 
-  it('Should render crop placeholder', () => {
-    const props: WebcamScannerProps = {
-      ...baseProps,
-      cropSize: { height: 400, width: 200 },
-    };
-    const wrapper = mount(<WebcamScanner {...props} />);
-    expect(
-      wrapper.find('[data-test-id="webcam-crop-placeholder"]').hostNodes()
-    ).toHaveLength(1);
-  });
+  describe('WebcamCropPlaceholder in WebcamScanner logic', () => {
+    const cropPlaceholderSelector = '[data-test-id="webcam-crop-placeholder"]';
+    it('Should render crop placeholder', () => {
+      const props: WebcamScannerProps = {
+        ...baseProps,
+        cropSize: { height: 400, width: 200 },
+      };
+      const wrapper = mount(<WebcamScanner {...props} />);
+      expect(wrapper.find(cropPlaceholderSelector).hostNodes()).toHaveLength(1);
+    });
 
-  it('Should not render crop placeholder', () => {
-    const wrapper = mount(<WebcamScanner {...baseProps} />);
-    expect(
-      wrapper.find('[data-test-id="webcam-crop-placeholder"]').hostNodes()
-    ).toHaveLength(0);
-  });
+    it('Should not render crop placeholder', () => {
+      const wrapper = mount(<WebcamScanner {...baseProps} />);
+      expect(wrapper.find(cropPlaceholderSelector).hostNodes()).toHaveLength(0);
+    });
 
-  it('Should hide crop placeholder when image is captured', () => {
-    const props: WebcamScannerProps = {
-      ...baseProps,
-      imageSrc: 'random imageSrc',
-      cropSize: { height: 400, width: 200 },
-    };
-    const wrapper = mount(<WebcamScanner {...props} />);
-    expect(
-      wrapper.find('[data-test-id="webcam-crop-placeholder"]').hostNodes()
-    ).toHaveLength(0);
+    it('Should hide crop placeholder when image is captured', () => {
+      const props: WebcamScannerProps = {
+        ...baseProps,
+        imageSrc: 'random imageSrc',
+        cropSize: { height: 400, width: 200 },
+      };
+      const wrapper = mount(<WebcamScanner {...props} />);
+      expect(wrapper.find(cropPlaceholderSelector).hostNodes()).toHaveLength(0);
+    });
   });
 });

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.test.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.test.tsx
@@ -1,0 +1,51 @@
+import { mount } from 'enzyme';
+import React from 'react';
+
+import { configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { WebcamScanner, WebcamScannerProps } from './WebcamScanner';
+
+configure({ adapter: new Adapter() });
+
+const baseProps: WebcamScannerProps = {
+  isLoading: false,
+  capture: jest.fn(),
+  setRef: jest.fn(),
+};
+
+describe('WebcamScanner', () => {
+  it('Should render without exploding', () => {
+    const wrapper = mount(<WebcamScanner {...baseProps} />);
+    expect(wrapper).toBeDefined();
+  });
+
+  it('Should render crop placeholder', () => {
+    const props: WebcamScannerProps = {
+      ...baseProps,
+      cropSize: { height: 400, width: 200 },
+    };
+    const wrapper = mount(<WebcamScanner {...props} />);
+    expect(
+      wrapper.find('[data-test-id="webcam-crop-placeholder"]').hostNodes()
+    ).toHaveLength(1);
+  });
+
+  it('Should not render crop placeholder', () => {
+    const wrapper = mount(<WebcamScanner {...baseProps} />);
+    expect(
+      wrapper.find('[data-test-id="webcam-crop-placeholder"]').hostNodes()
+    ).toHaveLength(0);
+  });
+
+  it('Should hide crop placeholder when image is captured', () => {
+    const props: WebcamScannerProps = {
+      ...baseProps,
+      imageSrc: 'random imageSrc',
+      cropSize: { height: 400, width: 200 },
+    };
+    const wrapper = mount(<WebcamScanner {...props} />);
+    expect(
+      wrapper.find('[data-test-id="webcam-crop-placeholder"]').hostNodes()
+    ).toHaveLength(0);
+  });
+});

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
@@ -7,15 +7,17 @@ import {
   PureObject,
   SetVideoRefCallback,
 } from '../../../interfaces';
+import { CropSize } from '../../../utils/utils';
 import { LoadingOverlay } from '../../common/LoadingOverlay/LoadingOverlay';
 import { ButtonRenderProp } from '../AssetScanner';
 import { Webcam } from '../Webcam/Webcam';
+import { WebcamCropPlaceholder } from '../WebcamCropPlaceholder/WebcamCropPlaceholder';
 import { WebcamScreenshot } from '../WebcamScreenshot/WebcamScreenshot';
 
 const CameraButton = styled.button`
   position: absolute;
   top: 50%;
-  left: 20px;
+  left: 25px;
   border-radius: 100%;
   width: 75px;
   height: 75px;
@@ -29,6 +31,7 @@ const CameraButton = styled.button`
   :hover {
     opacity: 1;
   }
+  z-index: 9999
 `;
 
 const Wrapper = styled.div`
@@ -60,6 +63,7 @@ interface WebcamScannerProps {
   strings?: PureObject;
   onError?: Callback;
   isReady?: boolean;
+  cropSize?: CropSize;
 }
 
 export function WebcamScanner({
@@ -73,8 +77,10 @@ export function WebcamScanner({
   onError,
   button,
   isReady = true,
+  cropSize,
 }: WebcamScannerProps) {
   const onCaptureClick = () => {
+    console.log('Clicked');
     if (isReady && capture) {
       capture();
     } else if (!isReady && onReset) {
@@ -107,6 +113,12 @@ export function WebcamScanner({
             {!isReady ? resultStrings.reset : ''}
           </CameraButton>
         ))}
+      {cropSize && !imageSrc && (
+        <WebcamCropPlaceholder
+          height={cropSize.height}
+          width={cropSize.width}
+        />
+      )}
     </Wrapper>
   );
 }

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
@@ -79,7 +79,6 @@ export function WebcamScanner({
   cropSize,
 }: WebcamScannerProps) {
   const onCaptureClick = () => {
-    console.log('Clicked');
     if (isReady && capture) {
       capture();
     } else if (!isReady && onReset) {

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
@@ -31,7 +31,6 @@ const CameraButton = styled.button`
   :hover {
     opacity: 1;
   }
-  z-index: 9999
 `;
 
 const Wrapper = styled.div`
@@ -101,6 +100,12 @@ export function WebcamScanner({
         onError={onError}
         style={imageSrc ? { opacity: 0, visability: 'hidden' } : {}}
       />
+      {cropSize && !imageSrc && (
+        <WebcamCropPlaceholder
+          height={cropSize.height}
+          width={cropSize.width}
+        />
+      )}
       {!isLoading &&
         (button ? (
           button(onCaptureClick, isReady)
@@ -113,12 +118,6 @@ export function WebcamScanner({
             {!isReady ? resultStrings.reset : ''}
           </CameraButton>
         ))}
-      {cropSize && !imageSrc && (
-        <WebcamCropPlaceholder
-          height={cropSize.height}
-          width={cropSize.width}
-        />
-      )}
     </Wrapper>
   );
 }

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
@@ -57,6 +57,7 @@ export interface WebcamScannerProps {
   setRef: SetVideoRefCallback;
   button?: ButtonRenderProp;
   imageSrc?: string;
+  imgAltText?: string;
   onReset?: EmptyCallback;
   styles?: WebcamScannerStyles;
   strings?: PureObject;
@@ -79,6 +80,7 @@ export function WebcamScanner({
   isReady = true,
   cropSize,
   webcamCropOverlay,
+  imgAltText,
 }: WebcamScannerProps) {
   const onCaptureClick = () => {
     if (isReady && capture) {
@@ -93,7 +95,7 @@ export function WebcamScanner({
   return (
     <Wrapper>
       <LoadingOverlay size={'large'} isLoading={isLoading} />
-      {imageSrc && <WebcamScreenshot src={imageSrc} />}
+      {imageSrc && <WebcamScreenshot src={imageSrc} altText={imgAltText} />}
       <Webcam
         audio={false}
         setRef={setRef}

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
@@ -57,7 +57,7 @@ export interface WebcamScannerProps {
   setRef: SetVideoRefCallback;
   button?: ButtonRenderProp;
   imageSrc?: string;
-  imgAltText?: string;
+  imageAltText?: string;
   onReset?: EmptyCallback;
   styles?: WebcamScannerStyles;
   strings?: PureObject;
@@ -80,7 +80,7 @@ export function WebcamScanner({
   isReady = true,
   cropSize,
   webcamCropOverlay,
-  imgAltText,
+  imageAltText,
 }: WebcamScannerProps) {
   const onCaptureClick = () => {
     if (isReady && capture) {
@@ -95,7 +95,7 @@ export function WebcamScanner({
   return (
     <Wrapper>
       <LoadingOverlay size={'large'} isLoading={isLoading} />
-      {imageSrc && <WebcamScreenshot src={imageSrc} altText={imgAltText} />}
+      {imageSrc && <WebcamScreenshot src={imageSrc} altText={imageAltText} />}
       <Webcam
         audio={false}
         setRef={setRef}

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
@@ -63,6 +63,7 @@ export interface WebcamScannerProps {
   onError?: Callback;
   isReady?: boolean;
   cropSize?: CropSize;
+  webcamCropOverlay?: React.ComponentType;
 }
 
 export function WebcamScanner({
@@ -77,6 +78,7 @@ export function WebcamScanner({
   button,
   isReady = true,
   cropSize,
+  webcamCropOverlay,
 }: WebcamScannerProps) {
   const onCaptureClick = () => {
     if (isReady && capture) {
@@ -104,6 +106,7 @@ export function WebcamScanner({
           data-test-id="webcam-crop-placeholder"
           height={cropSize.height}
           width={cropSize.width}
+          Component={webcamCropOverlay}
         />
       )}
       {!isLoading &&
@@ -121,3 +124,4 @@ export function WebcamScanner({
     </Wrapper>
   );
 }
+

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
@@ -3,11 +3,11 @@ import styled from 'styled-components';
 
 import {
   Callback,
+  CropSize,
   EmptyCallback,
   PureObject,
   SetVideoRefCallback,
 } from '../../../interfaces';
-import { CropSize } from '../../../utils/utils';
 import { LoadingOverlay } from '../../common/LoadingOverlay/LoadingOverlay';
 import { ButtonRenderProp } from '../AssetScanner';
 import { Webcam } from '../Webcam/Webcam';

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
@@ -51,7 +51,7 @@ export interface WebcamScannerStyles {
   button: React.CSSProperties;
 }
 
-interface WebcamScannerProps {
+export interface WebcamScannerProps {
   isLoading: boolean;
   capture: EmptyCallback;
   setRef: SetVideoRefCallback;
@@ -102,6 +102,7 @@ export function WebcamScanner({
       />
       {cropSize && !imageSrc && (
         <WebcamCropPlaceholder
+          data-test-id="webcam-crop-placeholder"
           height={cropSize.height}
           width={cropSize.width}
         />

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
@@ -17,7 +17,7 @@ import { WebcamScreenshot } from '../WebcamScreenshot/WebcamScreenshot';
 const CameraButton = styled.button`
   position: absolute;
   top: 50%;
-  left: 25px;
+  left: 20px;
   border-radius: 100%;
   width: 75px;
   height: 75px;

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
@@ -124,4 +124,3 @@ export function WebcamScanner({
     </Wrapper>
   );
 }
-

--- a/src/components/AssetScanner/WebcamScreenshot/WebcamScreenshot.tsx
+++ b/src/components/AssetScanner/WebcamScreenshot/WebcamScreenshot.tsx
@@ -21,18 +21,20 @@ const ImgWrapper = styled.img`
 
 interface WebcamScreenshotProps {
   src: string;
+  altText?: string;
   className?: string;
 }
 
 export function WebcamScreenshot({
   src,
+  altText = 'Captured from webcam',
   className = '',
 }: WebcamScreenshotProps) {
   return (
     <Wrapper>
       <ImgWrapper
         src={`data:image/png;base64,${src}`}
-        alt="Captured from webcam"
+        alt={altText}
         id="freezeFrame"
         className={className}
       />

--- a/src/components/AssetScanner/WebcamScreenshot/WebcamScreenshot.tsx
+++ b/src/components/AssetScanner/WebcamScreenshot/WebcamScreenshot.tsx
@@ -1,13 +1,22 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const Wrapper = styled.img`
+const Wrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 100%;
   max-width: 100%;
   position: absolute;
   min-width: 150px;
   top: 50%;
   transform: translate(0, -50%);
+`;
+
+// Ensures Img is displayed as it is cropped. Not being stretched in any direction
+const ImgWrapper = styled.img`
+  max-width: 100%;
+  max-height: 100%;
 `;
 
 interface WebcamScreenshotProps {
@@ -20,11 +29,13 @@ export function WebcamScreenshot({
   className = '',
 }: WebcamScreenshotProps) {
   return (
-    <Wrapper
-      src={`data:image/png;base64,${src}`}
-      alt="Captured from webcam"
-      id="freezeFrame"
-      className={className}
-    />
+    <Wrapper>
+      <ImgWrapper
+        src={`data:image/png;base64,${src}`}
+        alt="Captured from webcam"
+        id="freezeFrame"
+        className={className}
+      />
+    </Wrapper>
   );
 }

--- a/src/components/AssetScanner/stories/AssetScanner.stories.tsx
+++ b/src/components/AssetScanner/stories/AssetScanner.stories.tsx
@@ -204,4 +204,38 @@ storiesOf('AssetScanner/Examples', module)
         content: ocrRequestDoc,
       },
     }
+  )
+  .add(
+    'Horizontal placeholder with custom button',
+    () => (
+      <AssetScanner
+        onError={onError}
+        ocrRequest={ocrRequest}
+        onImageRecognizeFinish={onImageRecognizeFinish}
+        cropSize={{ width: 800, height: 250 }}
+        button={renderButton}
+      />
+    ),
+    {
+      readme: {
+        content: ocrRequestDoc,
+      },
+    }
+  )
+  .add(
+    'Vertical crop placeholder with custom button',
+    () => (
+      <AssetScanner
+        onError={onError}
+        ocrRequest={ocrRequest}
+        onImageRecognizeFinish={onImageRecognizeFinish}
+        cropSize={{ width: 200, height: 400 }}
+        button={renderButton}
+      />
+    ),
+    {
+      readme: {
+        content: ocrRequestDoc,
+      },
+    }
   );

--- a/src/components/AssetScanner/stories/AssetScanner.stories.tsx
+++ b/src/components/AssetScanner/stories/AssetScanner.stories.tsx
@@ -6,6 +6,8 @@ import styled from 'styled-components';
 import { Callback, ErrorResponse } from '../../../interfaces';
 import { ASNotifyTypes, AssetScanner } from '../AssetScanner';
 
+import cropPlaceholderCustomOverlayDoc from './crop-placeholder-custom-overlay.md';
+import cropPlaceholderDoc from './crop-placeholder.md';
 import customButtonDoc from './custom-button.md';
 import full from './full.md';
 import customNotificationsDoc from './notifications.md';
@@ -190,52 +192,34 @@ storiesOf('AssetScanner/Examples', module)
     />
   ))
   .add(
-    'Crop placeholder',
-    () => (
-      <AssetScanner
-        onError={onError}
-        ocrRequest={ocrRequest}
-        onImageRecognizeFinish={onImageRecognizeFinish}
-        cropSize={{ width: 400, height: 200 }}
-      />
-    ),
-    {
-      readme: {
-        content: ocrRequestDoc,
-      },
-    }
-  )
-  .add(
-    'Horizontal placeholder with custom button',
+    'Crop placeholder horizontal',
     () => (
       <AssetScanner
         onError={onError}
         ocrRequest={ocrRequest}
         onImageRecognizeFinish={onImageRecognizeFinish}
         cropSize={{ width: 800, height: 250 }}
-        button={renderButton}
       />
     ),
     {
       readme: {
-        content: ocrRequestDoc,
+        content: cropPlaceholderDoc,
       },
     }
   )
   .add(
-    'Vertical crop placeholder with custom button',
+    'Crop placeholder vertical',
     () => (
       <AssetScanner
         onError={onError}
         ocrRequest={ocrRequest}
         onImageRecognizeFinish={onImageRecognizeFinish}
         cropSize={{ width: 200, height: 400 }}
-        button={renderButton}
       />
     ),
     {
       readme: {
-        content: ocrRequestDoc,
+        content: cropPlaceholderDoc,
       },
     }
   )
@@ -247,7 +231,6 @@ storiesOf('AssetScanner/Examples', module)
         ocrRequest={ocrRequest}
         onImageRecognizeFinish={onImageRecognizeFinish}
         cropSize={{ width: 200, height: 400 }}
-        button={renderButton}
         webcamCropOverlay={() => (
           <div
             style={{
@@ -261,7 +244,7 @@ storiesOf('AssetScanner/Examples', module)
     ),
     {
       readme: {
-        content: ocrRequestDoc,
+        content: cropPlaceholderCustomOverlayDoc,
       },
     }
   );

--- a/src/components/AssetScanner/stories/AssetScanner.stories.tsx
+++ b/src/components/AssetScanner/stories/AssetScanner.stories.tsx
@@ -238,4 +238,30 @@ storiesOf('AssetScanner/Examples', module)
         content: ocrRequestDoc,
       },
     }
+  )
+  .add(
+    'Crop placeholder with custom overlay',
+    () => (
+      <AssetScanner
+        onError={onError}
+        ocrRequest={ocrRequest}
+        onImageRecognizeFinish={onImageRecognizeFinish}
+        cropSize={{ width: 200, height: 400 }}
+        button={renderButton}
+        webcamCropOverlay={() => (
+          <div
+            style={{
+              border: '20px solid red',
+              height: '440px',
+              width: '240px',
+            }}
+          />
+        )}
+      />
+    ),
+    {
+      readme: {
+        content: ocrRequestDoc,
+      },
+    }
   );

--- a/src/components/AssetScanner/stories/AssetScanner.stories.tsx
+++ b/src/components/AssetScanner/stories/AssetScanner.stories.tsx
@@ -188,4 +188,20 @@ storiesOf('AssetScanner/Examples', module)
         />
       )}
     />
-  ));
+  ))
+  .add(
+    'Crop placeholder',
+    () => (
+      <AssetScanner
+        onError={onError}
+        ocrRequest={ocrRequest}
+        onImageRecognizeFinish={onImageRecognizeFinish}
+        cropSize={{ width: 400, height: 200 }}
+      />
+    ),
+    {
+      readme: {
+        content: ocrRequestDoc,
+      },
+    }
+  );

--- a/src/components/AssetScanner/stories/crop-placeholder-custom-overlay.md
+++ b/src/components/AssetScanner/stories/crop-placeholder-custom-overlay.md
@@ -1,0 +1,42 @@
+## Custom ocrRequest function
+
+<!-- STORY -->  
+
+#### Usage:
+
+```typescript jsx
+import 'antd/dist/antd.css';
+
+import React from 'react';
+import { AssetScanner } from '@cognite/gearbox';
+
+import { doOcr } from 'your-ocr-implementation';
+import { extractStrings } from 'your-extract-strings-implementation';
+
+function ExampleComponent(props) {
+  const onError = (error: any): void => {};
+  const onImageRecognizeFinish = (strings: string[]): void => {};
+  const ocrRequest = async (image: string): Promise<string[]> => {
+    const recognise = await doOcr(image); 
+    return extractStrings(recognise);
+  };
+
+  return (
+    <AssetScanner
+        onError={onError}
+        ocrRequest={ocrRequest}
+        onImageRecognizeFinish={onImageRecognizeFinish}
+        cropSize={{ width: 400, height: 200 }}
+        webcamCropOverlay={() => (
+          <div
+            style={{
+              border: '20px solid red',
+              height: '440px',
+              width: '240px',
+            }}
+          />
+        )}
+      />
+  );
+}
+```

--- a/src/components/AssetScanner/stories/crop-placeholder.md
+++ b/src/components/AssetScanner/stories/crop-placeholder.md
@@ -1,0 +1,33 @@
+## Custom ocrRequest function
+
+<!-- STORY -->  
+
+#### Usage:
+
+```typescript jsx
+import 'antd/dist/antd.css';
+
+import React from 'react';
+import { AssetScanner } from '@cognite/gearbox';
+
+import { doOcr } from 'your-ocr-implementation';
+import { extractStrings } from 'your-extract-strings-implementation';
+
+function ExampleComponent(props) {
+  const onError = (error: any): void => {};
+  const onImageRecognizeFinish = (strings: string[]): void => {};
+  const ocrRequest = async (image: string): Promise<string[]> => {
+    const recognise = await doOcr(image); 
+    return extractStrings(recognise);
+  };
+
+  return (
+    <AssetScanner
+        onError={onError}
+        ocrRequest={ocrRequest}
+        onImageRecognizeFinish={onImageRecognizeFinish}
+        cropSize={{ width: 400, height: 200 }}
+      />
+  );
+}
+```

--- a/src/interfaces/CommonTypes.ts
+++ b/src/interfaces/CommonTypes.ts
@@ -47,3 +47,8 @@ export interface MouseScreenPosition {
   offsetX: number;
   offsetY: number;
 }
+
+export interface CropSize {
+  width: number;
+  height: number;
+}

--- a/src/utils/tests/utils.test.ts
+++ b/src/utils/tests/utils.test.ts
@@ -3,6 +3,9 @@ import Adapter from 'enzyme-adapter-react-16';
 import {
   clampNumber,
   extractValidStrings,
+  scaleCropSizeToVideoResolution,
+  scaleDomToVideoResolution,
+  shouldScaleYAxis,
   sortStringsAlphabetically,
 } from '../utils';
 
@@ -62,5 +65,80 @@ describe('utils', () => {
         expect(extractValidStrings(arr, maxLen, minLen)).toEqual(expected);
       }
     );
+  });
+
+  describe('WebCamCropper', () => {
+    describe('Camera direction', () => {
+      it('should be horizontal', () => {
+        expect(shouldScaleYAxis(720, 1280, 1029, 1631)).toBeTruthy();
+      });
+      it('should be vertical', () => {
+        expect(shouldScaleYAxis(720, 1280, 1029, 1948)).toBeFalsy();
+      });
+    });
+
+    describe('AdjustCropSizeToVideoResolution', () => {
+      it('should return undefined when cropsize is undefined', () => {
+        expect(
+          scaleCropSizeToVideoResolution(0, 0, 0, 0, undefined)
+        ).toBeUndefined();
+      });
+      const cropSize = { width: 400, height: 200 };
+      it('should scale 1 to 1', () => {
+        const scaled = scaleCropSizeToVideoResolution(
+          1000,
+          1000,
+          1000,
+          1000,
+          cropSize
+        );
+        expect(scaled).toEqual({ width: 400, height: 200 });
+      });
+      it('should scale 1 to 2', () => {
+        const scaled = scaleCropSizeToVideoResolution(
+          500,
+          500,
+          1000,
+          1000,
+          cropSize
+        );
+        expect(scaled).toEqual({ width: 200, height: 100 });
+      });
+    });
+
+    describe('ScaleDomToVideoResolution', () => {
+      it('should scale correctly', () => {
+        const scaled = scaleDomToVideoResolution(10, 10, 20, 20);
+        expect(scaled).toBeDefined();
+      });
+      it('should scale horizontaly with height but not width', () => {
+        const sourceClientWidth = 1154;
+        const sourceClientHeight = 1029;
+        const scaled = scaleDomToVideoResolution(
+          720,
+          1280,
+          sourceClientHeight,
+          sourceClientWidth
+        );
+        expect(scaled).toEqual({
+          clientHeight: 649, // this is scaled
+          clientWidth: sourceClientWidth,
+        });
+      });
+      it('should scale vertically with width but not height', () => {
+        const sourceClientWidth = 2000;
+        const sourceClientHeight = 1001;
+        const scaled = scaleDomToVideoResolution(
+          720,
+          1280,
+          sourceClientHeight,
+          sourceClientWidth
+        );
+        expect(scaled).toEqual({
+          clientHeight: sourceClientHeight,
+          clientWidth: 1780, // this is scaled
+        });
+      });
+    });
   });
 });

--- a/src/utils/tests/utils.test.ts
+++ b/src/utils/tests/utils.test.ts
@@ -85,21 +85,18 @@ describe('utils', () => {
       });
       const cropSize = { width: 400, height: 200 };
       it('should scale 1 to 1', () => {
-        const scaled = scaleCropSizeToVideoResolution(
-          1000,
-          1000,
-          1000,
-          1000,
-          cropSize
-        );
+        const px = 1000;
+        const scaled = scaleCropSizeToVideoResolution(px, px, px, px, cropSize);
         expect(scaled).toEqual({ width: 400, height: 200 });
       });
+
       it('should scale 1 to 2', () => {
+        const px = 1000;
         const scaled = scaleCropSizeToVideoResolution(
-          500,
-          500,
-          1000,
-          1000,
+          px / 2,
+          px / 2,
+          px,
+          px,
           cropSize
         );
         expect(scaled).toEqual({ width: 200, height: 100 });

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -113,6 +113,10 @@ export const scaleDomToVideoResolution = (
   return scaledClient;
 };
 
+/**
+ * Because the canvas uses the video resolution, we need to scale the clientPx to fit the videoPx
+ * That way the users perception of the cropped area is the same as the actual cropping.
+ */
 export const scaleCropSizeToVideoResolution = (
   videoHeight: number,
   videoWidth: number,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -15,7 +15,7 @@ export function getMiddlePixelsOfContainer(
   parentHeight: number
 ) {
   return {
-    sx: Math.ceil((parentWidth - width) / 2),
+    sx: Math.floor((parentWidth - width) / 2),
     sy: Math.ceil((parentHeight - height) / 2),
     sw: width,
     sh: height,
@@ -37,23 +37,13 @@ export function getCanvas(
   cropSize?: CropSize
 ) {
   const canvas = document.createElement('canvas');
-
   canvas.width = width;
   canvas.height = height;
 
   const ctx = canvas.getContext('2d');
 
   const cropProps = cropSize
-    ? {
-        sx: Math.ceil((canvas.width - cropSize.width) / 2),
-        sy: Math.ceil((canvas.height - cropSize.height) / 2),
-        sw: cropSize.width,
-        sh: cropSize.height,
-        dx: Math.ceil((canvas.width - cropSize.width) / 2),
-        dy: Math.ceil((canvas.height - cropSize.height) / 2),
-        dw: cropSize.width,
-        dh: cropSize.height,
-      }
+    ? getMiddlePixelsOfContainer(cropSize.width, cropSize.height, width, height)
     : {
         sx: 0,
         sy: 0,
@@ -66,7 +56,9 @@ export function getCanvas(
       };
 
   if (ctx) {
-    console.log('Cropping', 'W:', width, ' H:', height);
+    console.log('video CH:', img.clientHeight, 'video CW:', img.clientWidth);
+    console.log('Video sizes', ' VH:', height, 'VW:', width);
+    console.log('Crop sizes', cropSize);
     console.log(cropProps);
     ctx.drawImage(
       img,
@@ -83,6 +75,8 @@ export function getCanvas(
 
   return canvas;
 }
+
+export const calculateAdjustedCropSize = () => {};
 
 export function extractValidStrings(
   textAnnotations: Asset[] = [],

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -56,10 +56,6 @@ export function getCanvas(
       };
 
   if (ctx) {
-    console.log('video CH:', img.clientHeight, 'video CW:', img.clientWidth);
-    console.log('Video sizes', ' VH:', height, 'VW:', width);
-    console.log('Crop sizes', cropSize);
-    console.log(cropProps);
     ctx.drawImage(
       img,
       cropProps.sx,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -42,18 +42,20 @@ export function getCanvas(
 
   const ctx = canvas.getContext('2d');
 
+  const fullContainer = {
+    sx: 0,
+    sy: 0,
+    sw: canvas.width,
+    sh: canvas.height,
+    dx: 0,
+    dy: 0,
+    dw: canvas.width,
+    dh: canvas.height,
+  };
+
   const cropProps = cropSize
     ? getMiddlePixelsOfContainer(cropSize.width, cropSize.height, width, height)
-    : {
-        sx: 0,
-        sy: 0,
-        sw: canvas.width,
-        sh: canvas.height,
-        dx: 0,
-        dy: 0,
-        dw: canvas.width,
-        dh: canvas.height,
-      };
+    : fullContainer;
 
   if (ctx) {
     ctx.drawImage(

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -72,7 +72,59 @@ export function getCanvas(
   return canvas;
 }
 
-export const calculateAdjustedCropSize = () => {};
+export const shouldScaleYAxis = (
+  videoHeight: number,
+  videoWidth: number,
+  clientHeight: number,
+  clientWidth: number
+): boolean => {
+  const clientRatio = clientWidth / clientHeight;
+  const videoRatio = videoWidth / videoHeight;
+  return clientRatio < videoRatio;
+};
+
+export const scaleDomToVideoResolution = (
+  videoHeight: number,
+  videoWidth: number,
+  sourceClientHeight: number,
+  sourceClientWidth: number
+): { clientHeight: number; clientWidth: number } => {
+  const isScalingYAxis = shouldScaleYAxis(
+    videoHeight,
+    videoWidth,
+    sourceClientHeight,
+    sourceClientWidth
+  );
+  const scaledClient = {
+    clientHeight: sourceClientHeight,
+    clientWidth: sourceClientWidth,
+  };
+  if (isScalingYAxis) {
+    scaledClient.clientHeight = Math.round(
+      (sourceClientWidth * videoHeight) / videoWidth
+    );
+  } else {
+    scaledClient.clientWidth = Math.round(
+      (videoWidth * sourceClientHeight) / videoHeight
+    );
+  }
+  return scaledClient;
+};
+
+export const scaleCropSizeToVideoResolution = (
+  videoHeight: number,
+  videoWidth: number,
+  clientHeight: number,
+  clientWidth: number,
+  initialCropSize?: CropSize
+): CropSize | undefined => {
+  return initialCropSize
+    ? {
+        height: initialCropSize.height * (videoHeight / clientHeight),
+        width: initialCropSize.width * (videoWidth / clientWidth),
+      }
+    : undefined;
+};
 
 export function extractValidStrings(
   textAnnotations: Asset[] = [],

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -8,10 +8,33 @@ export function sortStringsAlphabetically(a: string, b: string): number {
   return a < b ? -1 : a > b ? 1 : 0;
 }
 
+export function getMiddlePixelsOfContainer(
+  width: number,
+  height: number,
+  parentWidth: number,
+  parentHeight: number
+) {
+  return {
+    sx: Math.ceil((parentWidth - width) / 2),
+    sy: Math.ceil((parentHeight - height) / 2),
+    sw: width,
+    sh: height,
+    dx: Math.ceil((parentWidth - width) / 2),
+    dy: Math.ceil((parentHeight - height) / 2),
+    dw: width,
+    dh: height,
+  };
+}
+
+export interface CropSize {
+  width: number;
+  height: number;
+}
 export function getCanvas(
   img: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
   width: number,
-  height: number
+  height: number,
+  cropSize?: CropSize
 ) {
   const canvas = document.createElement('canvas');
 
@@ -20,8 +43,42 @@ export function getCanvas(
 
   const ctx = canvas.getContext('2d');
 
+  const cropProps = cropSize
+    ? {
+        sx: Math.ceil((canvas.width - cropSize.width) / 2),
+        sy: Math.ceil((canvas.height - cropSize.height) / 2),
+        sw: cropSize.width,
+        sh: cropSize.height,
+        dx: Math.ceil((canvas.width - cropSize.width) / 2),
+        dy: Math.ceil((canvas.height - cropSize.height) / 2),
+        dw: cropSize.width,
+        dh: cropSize.height,
+      }
+    : {
+        sx: 0,
+        sy: 0,
+        sw: canvas.width,
+        sh: canvas.height,
+        dx: 0,
+        dy: 0,
+        dw: canvas.width,
+        dh: canvas.height,
+      };
+
   if (ctx) {
-    ctx.drawImage(img, 0, 0, canvas.width, canvas.height);
+    console.log('Cropping', 'W:', width, ' H:', height);
+    console.log(cropProps);
+    ctx.drawImage(
+      img,
+      cropProps.sx,
+      cropProps.sy,
+      cropProps.sw,
+      cropProps.sh,
+      cropProps.dx,
+      cropProps.dy,
+      cropProps.dw,
+      cropProps.dh
+    );
   }
 
   return canvas;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
 import { Asset } from '@cognite/sdk';
+import { CropSize } from '..';
 
 export function clampNumber(v: number, minValue: number, maxValue: number) {
   return Math.max(Math.min(v, maxValue), minValue);
@@ -26,10 +27,6 @@ export function getMiddlePixelsOfContainer(
   };
 }
 
-export interface CropSize {
-  width: number;
-  height: number;
-}
 export function getCanvas(
   img: HTMLImageElement | HTMLCanvasElement | HTMLVideoElement,
   width: number,


### PR DESCRIPTION
To better support tags that are hard to recognise when sending the complete camera picture I would like to add the following:

Optional cropping on the AsserScanner.
Cropping overlay/display-placeholder to support UX.

This should make it easier to send pictures with less noise to OCR.

Solution:
Using canvas to crop the video-screenshot and redisplay.

AssetScanner will get a CropSize property which enables the react app to crop i different sizes based on media size and wanted UX. Also allows different sizes on different customers/assets and so on.




