### PR TITLE
v0.0.46 - Image cropper for Asset scanner

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/gearbox",
-  "version": "0.0.45",
+  "version": "0.0.46",
   "description": "GearBox will be a place for application developers to contribute useful, reusable components across applications",
   "contributors": [],
   "main": "dist/index.js",


### PR DESCRIPTION
Image cropper for Assetscanner should be 100% backwards compatible, with no breaking changes.

Client can add a cropSize prop to AssetScanner to allow the video snapshot to be cropped. 
AssetScanner will add a darkened overlay to show where the cropping will happen.
The client can also add a custom overlay component to customize help based on user needs.