### PR TITLE
Instant search if image was provided

### DIFF
--- a/src/components/AssetScanner/AssetScanner.tsx
+++ b/src/components/AssetScanner/AssetScanner.tsx
@@ -155,13 +155,13 @@ export class AssetScanner extends React.Component<
 
     const image = removeImageBase(this.props.image);
     const { imageSrc, isLoading } = this.state;
-
     if (
       !isLoading &&
       image !== imageSrc &&
       this.props.image !== prevProps.image
     ) {
       this.setState({ imageSrc: image });
+      this.capture();
     }
   }
 


### PR DESCRIPTION
In case if an image was sent as a prop to `AssetScanner` it makes sense to start searching instantly.