### PR TITLE
Do not validate empty tenants

### DIFF
--- a/src/components/TenantSelector/TenantSelector.test.tsx
+++ b/src/components/TenantSelector/TenantSelector.test.tsx
@@ -77,14 +77,18 @@ describe('TenantSelector', () => {
   });
 
   it('Handles empty tenants (with callback)', done => {
-    const validateTenant = sinon.fake.rejects(new Error('Testing'));
-    const onInvalidTenant = sinon.fake();
     const wrapper = mount(
       <TenantSelector
-        onInvalidTenant={onInvalidTenant}
-        onTenantSelected={done.fail}
+        onInvalidTenant={() =>
+          done.fail('onInvalidTenant should not be called without text')
+        }
+        onTenantSelected={() =>
+          done.fail('onTenantSelected should not be called without text')
+        }
         title="Unit Test"
-        validateTenant={validateTenant}
+        validateTenant={() =>
+          done.fail('validateTenant should not be called without text')
+        }
       />
     );
 
@@ -94,12 +98,8 @@ describe('TenantSelector', () => {
     const input = wrapper.find(tenantInputDataId);
 
     // Without any text entered, clicking the button doesn't do anything.
-    expect(validateTenant.callCount).toEqual(0);
     input.simulate('change', { target: { value: '' } });
     input.simulate('keydown', { keyCode: 13 });
-    expect(validateTenant.callCount).toEqual(0);
-    expect(onInvalidTenant.callCount).toEqual(1);
-    expect(onInvalidTenant.lastCall.args[0]).toEqual('');
     done();
   });
 

--- a/src/components/TenantSelector/TenantSelector.tsx
+++ b/src/components/TenantSelector/TenantSelector.tsx
@@ -53,7 +53,7 @@ interface TenantSelectorState {
 export class TenantSelector extends React.Component<
   TenantSelectorProps,
   TenantSelectorState
-  > {
+> {
   static defaultProps = {
     advancedOptions: {},
   };
@@ -138,10 +138,10 @@ export class TenantSelector extends React.Component<
         {header && typeof header !== 'string' ? (
           header
         ) : (
-            <SubTitle style={styles && styles.subTitle}>
-              {header || 'Enter your company name'}
-            </SubTitle>
-          )}
+          <SubTitle style={styles && styles.subTitle}>
+            {header || 'Enter your company name'}
+          </SubTitle>
+        )}
         <Form>
           <Form.Item hasFeedback={true} {...formItemProps}>
             <Input
@@ -341,7 +341,7 @@ const LoginButton = styled((props: NativeButtonProps) => <Button {...props} />)`
   &:disabled:hover {
     border-color: ${({ theme }) => theme.gearbox.buttonBorderColor} !important;
     background-color: ${({ theme }) =>
-    theme.gearbox.buttonDisabledColor} !important;
+      theme.gearbox.buttonDisabledColor} !important;
     color: ${({ theme }) => theme.gearbox.textColorDisabled};
   }
 `;

--- a/src/components/TenantSelector/TenantSelector.tsx
+++ b/src/components/TenantSelector/TenantSelector.tsx
@@ -53,7 +53,7 @@ interface TenantSelectorState {
 export class TenantSelector extends React.Component<
   TenantSelectorProps,
   TenantSelectorState
-> {
+  > {
   static defaultProps = {
     advancedOptions: {},
   };
@@ -138,10 +138,10 @@ export class TenantSelector extends React.Component<
         {header && typeof header !== 'string' ? (
           header
         ) : (
-          <SubTitle style={styles && styles.subTitle}>
-            {header || 'Enter your company name'}
-          </SubTitle>
-        )}
+            <SubTitle style={styles && styles.subTitle}>
+              {header || 'Enter your company name'}
+            </SubTitle>
+          )}
         <Form>
           <Form.Item hasFeedback={true} {...formItemProps}>
             <Input
@@ -149,7 +149,7 @@ export class TenantSelector extends React.Component<
               data-id="tenant-input"
               autoFocus={true}
               onChange={this.onTenantChange}
-              onPressEnter={tenant ? this.checkTenantValidity : undefined}
+              onPressEnter={this.checkTenantValidity}
               value={tenant}
               defaultValue={tenant}
               placeholder={placeholder || 'cognite'}
@@ -192,7 +192,9 @@ export class TenantSelector extends React.Component<
   private checkTenantValidity = async () => {
     const { onInvalidTenant, onTenantSelected, validateTenant } = this.props;
     const { tenant, advanced } = this.state;
-
+    if (!tenant) {
+      return;
+    }
     const advancedOptions = Object.keys(advanced).length
       ? this.getNonEmptyAdvancedFields(advanced)
       : null;
@@ -339,7 +341,7 @@ const LoginButton = styled((props: NativeButtonProps) => <Button {...props} />)`
   &:disabled:hover {
     border-color: ${({ theme }) => theme.gearbox.buttonBorderColor} !important;
     background-color: ${({ theme }) =>
-      theme.gearbox.buttonDisabledColor} !important;
+    theme.gearbox.buttonDisabledColor} !important;
     color: ${({ theme }) => theme.gearbox.textColorDisabled};
   }
 `;

--- a/src/components/TenantSelector/TenantSelector.tsx
+++ b/src/components/TenantSelector/TenantSelector.tsx
@@ -149,7 +149,7 @@ export class TenantSelector extends React.Component<
               data-id="tenant-input"
               autoFocus={true}
               onChange={this.onTenantChange}
-              onPressEnter={this.checkTenantValidity}
+              onPressEnter={tenant ? this.checkTenantValidity : undefined}
               value={tenant}
               defaultValue={tenant}
               placeholder={placeholder || 'cognite'}


### PR DESCRIPTION
When a tenant has not been entered, don't let the user press Enter to
validate the tenant -- it's clearly invalid.