### PR TITLE
Added right click functionality to 3DNodeTree

### DIFF
--- a/src/components/ThreeDNodeTree/ThreeDNodeTree.tsx
+++ b/src/components/ThreeDNodeTree/ThreeDNodeTree.tsx
@@ -1,7 +1,11 @@
 import { Node, ThreeDListNodesParams } from '@cognite/sdk';
 import * as sdk from '@cognite/sdk';
 import { Tree } from 'antd';
-import { AntTreeNode, AntTreeNodeProps, AntTreeNodeMouseEvent } from 'antd/lib/tree';
+import {
+  AntTreeNode,
+  AntTreeNodeMouseEvent,
+  AntTreeNodeProps,
+} from 'antd/lib/tree';
 import React from 'react';
 import styled from 'styled-components';
 import { withDefaultTheme } from '../../hoc/withDefaultTheme';

--- a/src/components/ThreeDNodeTree/ThreeDNodeTree.tsx
+++ b/src/components/ThreeDNodeTree/ThreeDNodeTree.tsx
@@ -1,7 +1,7 @@
 import { Node, ThreeDListNodesParams } from '@cognite/sdk';
 import * as sdk from '@cognite/sdk';
 import { Tree } from 'antd';
-import { AntTreeNode, AntTreeNodeProps } from 'antd/lib/tree';
+import { AntTreeNode, AntTreeNodeProps, AntTreeNodeMouseEvent } from 'antd/lib/tree';
 import React from 'react';
 import styled from 'styled-components';
 import { withDefaultTheme } from '../../hoc/withDefaultTheme';
@@ -190,6 +190,13 @@ class ThreeDNodeTree extends React.Component<NodeTreeProps, NodeTreeState> {
     }
   };
 
+  onRightClickNode = (event: AntTreeNodeMouseEvent) => {
+    const { onRightClick } = this.props;
+    if (onRightClick) {
+      onRightClick(event);
+    }
+  };
+
   onExpand = (expandedKeys: string[]) => {
     this.setState({
       expandedKeys: ThreeDNodeTree.toKeys(
@@ -233,6 +240,7 @@ class ThreeDNodeTree extends React.Component<NodeTreeProps, NodeTreeState> {
         expandedKeys={Object.keys(expandedKeys)}
         onExpand={this.onExpand}
         loadedKeys={this.state.loadedKeys}
+        onRightClick={this.onRightClickNode}
       >
         {this.renderTreeNode(treeData)}
       </Tree>

--- a/src/components/ThreeDNodeTree/stories/ThreeDNodeTree.stories.tsx
+++ b/src/components/ThreeDNodeTree/stories/ThreeDNodeTree.stories.tsx
@@ -1,9 +1,15 @@
 import * as sdk from '@cognite/sdk';
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
+import { Menu } from 'antd';
+import { ClickParam } from 'antd/lib/menu';
+import MenuItem from 'antd/lib/menu/MenuItem';
 import React from 'react';
 import { ThemeProvider } from 'styled-components';
-import { OnSelectNodeTreeParams } from '../../../interfaces';
+import {
+  OnRightClickNodeTreeParams,
+  OnSelectNodeTreeParams,
+} from '../../../interfaces';
 import {
   ASSET_TREE_STYLES,
   KEY_LIST,
@@ -17,6 +23,7 @@ import clickItem from './clickItem.md';
 import customStyles from './customStyles.md';
 import defaultExpanded from './defaultExpanded.md';
 import fullDescription from './full.md';
+import rightClickItem from './rightClickItem.md';
 import withTheme from './withTheme.md';
 
 const setupMocks = () => {
@@ -44,6 +51,82 @@ const setupMocks = () => {
     return { items: NODE_LIST };
   };
 };
+
+interface RightClickState {
+  visible: boolean;
+  rightClickedNode?: string;
+  menuStyle: {
+    [_: string]: string;
+  };
+}
+
+class RightClickExample extends React.Component<{}, RightClickState> {
+  constructor(props: {}) {
+    super(props);
+    this.state = {
+      visible: false,
+      menuStyle: {},
+    };
+  }
+  showSubMenu = () => {
+    return this.state.visible ? (
+      <Menu
+        theme="dark"
+        style={this.state.menuStyle}
+        onClick={(params: ClickParam) => {
+          if (this.state.rightClickedNode) {
+            switch (params.key) {
+              case '1': {
+                alert('1: ' + this.state.rightClickedNode);
+                break;
+              }
+              case '2': {
+                alert('2: ' + this.state.rightClickedNode);
+                break;
+              }
+              default:
+                break;
+            }
+          }
+        }}
+      >
+        <MenuItem key="1">Menu Item 1</MenuItem>
+        <MenuItem key="2">Menu Item 2</MenuItem>
+      </Menu>
+    ) : (
+      <></>
+    );
+  };
+  componentDidMount() {
+    document.addEventListener('click', () => {
+      this.setState({
+        visible: false,
+      });
+    });
+  }
+  render() {
+    return (
+      <>
+        <ThreeDNodeTree
+          modelId={6265454237631097}
+          revisionId={3496204575166890}
+          onRightClick={(e: OnRightClickNodeTreeParams) => {
+            this.setState({
+              visible: true,
+              menuStyle: {
+                position: 'fixed',
+                top: `${e.event.clientY}px`,
+                left: `${e.event.clientX + 20}px`,
+              },
+              rightClickedNode: e.node.props.title,
+            });
+          }}
+        />
+        {this.showSubMenu()}
+      </>
+    );
+  }
+}
 
 storiesOf('ThreeDNodeTree', module).add(
   'Full description',
@@ -74,6 +157,18 @@ storiesOf('ThreeDNodeTree/Examples', module)
     {
       readme: {
         content: clickItem,
+      },
+    }
+  )
+  .add(
+    'Right Click Item in Tree',
+    () => {
+      setupMocks();
+      return <RightClickExample />;
+    },
+    {
+      readme: {
+        content: rightClickItem,
       },
     }
   )

--- a/src/components/ThreeDNodeTree/stories/ThreeDNodeTree.stories.tsx
+++ b/src/components/ThreeDNodeTree/stories/ThreeDNodeTree.stories.tsx
@@ -2,7 +2,6 @@ import * as sdk from '@cognite/sdk';
 import { action } from '@storybook/addon-actions';
 import { storiesOf } from '@storybook/react';
 import { Menu } from 'antd';
-import { ClickParam } from 'antd/lib/menu';
 import MenuItem from 'antd/lib/menu/MenuItem';
 import React from 'react';
 import { ThemeProvider } from 'styled-components';
@@ -61,6 +60,7 @@ interface RightClickState {
 }
 
 class RightClickExample extends React.Component<{}, RightClickState> {
+  menu: HTMLDivElement | null = null;
   constructor(props: {}) {
     super(props);
     this.state = {
@@ -68,37 +68,31 @@ class RightClickExample extends React.Component<{}, RightClickState> {
       menuStyle: {},
     };
   }
-  showSubMenu = () => {
+  renderSubMenu = () => {
     return this.state.visible ? (
       <Menu
         theme="dark"
         style={this.state.menuStyle}
-        onClick={(params: ClickParam) => {
+        onClick={() => {
           if (this.state.rightClickedNode) {
-            switch (params.key) {
-              case '1': {
-                alert('1: ' + this.state.rightClickedNode);
-                break;
-              }
-              case '2': {
-                alert('2: ' + this.state.rightClickedNode);
-                break;
-              }
-              default:
-                break;
-            }
+            alert(this.state.rightClickedNode);
           }
         }}
       >
-        <MenuItem key="1">Menu Item 1</MenuItem>
-        <MenuItem key="2">Menu Item 2</MenuItem>
+        <MenuItem>Menu Item 1</MenuItem>
+        <MenuItem>Menu Item 2</MenuItem>
       </Menu>
     ) : (
       <></>
     );
   };
   componentDidMount() {
-    document.addEventListener('click', () => {
+    document.body.addEventListener('click', (e: MouseEvent) => {
+      // Ignore clicks on the context menu itself
+      if (this.menu && this.menu.contains(e.target as Node)) {
+        return;
+      }
+      // Close context menu when click outside of it
       this.setState({
         visible: false,
       });
@@ -122,7 +116,7 @@ class RightClickExample extends React.Component<{}, RightClickState> {
             });
           }}
         />
-        {this.showSubMenu()}
+        <div ref={node => (this.menu = node)}>{this.renderSubMenu()}</div>
       </>
     );
   }

--- a/src/components/ThreeDNodeTree/stories/full.md
+++ b/src/components/ThreeDNodeTree/stories/full.md
@@ -40,6 +40,7 @@ function ExampleComponent(props) {
 | Property              | Description                                 | Type                        | Default |
 | --------------------- | ------------------------------------------- | --------------------------- | ------- |
 | `onSelect`            | Triggers when a node is selected            | `(onSelect: OnSelectNodeTreeParams) => void` | `onSelect:  (selectedNode : OnSelectNodeTreeParams) => selectedNode.key`|
+| `onRightClick`            | Triggers when a node is right clicked            | `(onRightClick: OnRightClickNodeTreeParams) => void` | |
 | `defaultExpandedKeys` | List of node ids to be expanded by default  | `number[]`                  | [ ] |
 | `styles`              | Object that defines inline CSS styles for inner elements of the component.| `NodeTreeStyles` |  |
 
@@ -63,6 +64,25 @@ interface OnSelectNodeTreeParams {
   title: string;
   isLeaf?: boolean;
   node?: Node;
+}
+
+```
+
+#### OnRightClickNodeTreeParams
+
+This type describes the parameters the `onRightClick` function is called with.
+The type can be imported from @cognite/gearbox:
+
+```typescript
+import { OnRightClickNodeTreeParams } from '@cognite/gearbox';
+```
+
+Definition:
+
+```typescript
+interface OnRightClickNodeTreeParams {
+  event: React.MouseEvent<any>;
+  node: AntTreeNodeProps;
 }
 
 ```

--- a/src/components/ThreeDNodeTree/stories/rightClickItem.md
+++ b/src/components/ThreeDNodeTree/stories/rightClickItem.md
@@ -28,44 +28,39 @@ interface RightClickState {
 ```
 ```typescript jsx
 class ExampleComponent extends React.Component<{}, RightClickState> {
-  constructor(props:{}) {
+  menu: HTMLDivElement | null = null;
+  constructor(props: {}) {
     super(props);
     this.state = {
       visible: false,
       menuStyle: {},
     };
   }
-  showSubMenu = () => {
+  renderSubMenu = () => {
     return this.state.visible ? (
       <Menu
         theme="dark"
         style={this.state.menuStyle}
-        onClick={(params: ClickParam) => {
+        onClick={() => {
           if (this.state.rightClickedNode) {
-            switch (params.key) {
-              case '1': {
-                alert('1: ' + this.state.rightClickedNode);
-                break;
-              }
-              case '2': {
-                alert('2: ' + this.state.rightClickedNode);
-                break;
-              }
-              default:
-                break;
-            }
+            alert(this.state.rightClickedNode);
           }
         }}
       >
-        <MenuItem key="1">Menu Item 1</MenuItem>
-        <MenuItem key="2">Menu Item 2</MenuItem>
+        <MenuItem>Menu Item 1</MenuItem>
+        <MenuItem>Menu Item 2</MenuItem>
       </Menu>
     ) : (
       <></>
     );
   };
   componentDidMount() {
-    document.addEventListener('click', () => {
+    document.body.addEventListener('click', (e: MouseEvent) => {
+      // Ignore clicks on the context menu itself
+      if (this.menu && this.menu.contains(e.target as Node)) {
+        return;
+      }
+      // Close context menu when click outside of it
       this.setState({
         visible: false,
       });
@@ -75,8 +70,8 @@ class ExampleComponent extends React.Component<{}, RightClickState> {
     return (
       <>
         <ThreeDNodeTree
-          modelId={0}
-          revisionId={0}
+          modelId={6265454237631097}
+          revisionId={3496204575166890}
           onRightClick={(e: OnRightClickNodeTreeParams) => {
             this.setState({
               visible: true,
@@ -89,7 +84,7 @@ class ExampleComponent extends React.Component<{}, RightClickState> {
             });
           }}
         />
-        {this.showSubMenu()}
+        <div ref={node => (this.menu = node)}>{this.renderSubMenu()}</div>
       </>
     );
   }

--- a/src/components/ThreeDNodeTree/stories/rightClickItem.md
+++ b/src/components/ThreeDNodeTree/stories/rightClickItem.md
@@ -1,0 +1,97 @@
+## Right click item in tree 
+
+<!-- STORY -->
+
+#### Description:
+
+Users can customize right click behaviors through the onRightClick prop of the component. 
+The following is an example of popping up a customized context menu when a tree node is right clicked. From the input of onRightClick function, users are able to access the tree node and click event information, which can be applied to define different actions the items in the menu. 
+
+#### Usage:
+
+```typescript jsx
+import 'antd/dist/antd.css';
+import React from 'react';
+import { Menu } from 'antd';
+import MenuItem from 'antd/lib/menu/MenuItem';
+import { ClickParam } from 'antd/lib/menu';
+import { ThreeDNodeTree, OnRightClickNodeTreeParams } from '@cognite/gearbox';
+```
+```typescript jsx
+interface RightClickState {
+  visible: boolean;
+  rightClickedNode?: string;
+  menuStyle: {
+    [_: string]: string;
+  };
+}
+```
+```typescript jsx
+class ExampleComponent extends React.Component<{}, RightClickState> {
+  constructor(props:{}) {
+    super(props);
+    this.state = {
+      visible: false,
+      menuStyle: {},
+    };
+  }
+  showSubMenu = () => {
+    return this.state.visible ? (
+      <Menu
+        theme="dark"
+        style={this.state.menuStyle}
+        onClick={(params: ClickParam) => {
+          if (this.state.rightClickedNode) {
+            switch (params.key) {
+              case '1': {
+                alert('1: ' + this.state.rightClickedNode);
+                break;
+              }
+              case '2': {
+                alert('2: ' + this.state.rightClickedNode);
+                break;
+              }
+              default:
+                break;
+            }
+          }
+        }}
+      >
+        <MenuItem key="1">Menu Item 1</MenuItem>
+        <MenuItem key="2">Menu Item 2</MenuItem>
+      </Menu>
+    ) : (
+      <></>
+    );
+  };
+  componentDidMount() {
+    document.addEventListener('click', () => {
+      this.setState({
+        visible: false,
+      });
+    });
+  }
+  render() {
+    return (
+      <>
+        <ThreeDNodeTree
+          modelId={0}
+          revisionId={0}
+          onRightClick={(e: OnRightClickNodeTreeParams) => {
+            this.setState({
+              visible: true,
+              menuStyle: {
+                position: 'fixed',
+                top: `${e.event.clientY}px`,
+                left: `${e.event.clientX + 20}px`,
+              },
+              rightClickedNode: e.node.props.title,
+            });
+          }}
+        />
+        {this.showSubMenu()}
+      </>
+    );
+  }
+}
+```

--- a/src/interfaces/NodeTypes.ts
+++ b/src/interfaces/NodeTypes.ts
@@ -12,7 +12,7 @@ export interface OnSelectNodeTreeParams {
 }
 
 export interface OnRightClickNodeTreeParams {
-  event: React.MouseEvent<any>;
+  event: React.MouseEvent<HTMLElement>;
   node: AntTreeNodeProps;
 }
 

--- a/src/interfaces/NodeTypes.ts
+++ b/src/interfaces/NodeTypes.ts
@@ -1,4 +1,5 @@
 import { Node } from '@cognite/sdk';
+import { AntTreeNodeProps } from 'antd/lib/tree';
 import { AnyIfEmpty } from './CommonTypes';
 
 export type NodePanelType = 'details' | 'events' | 'documents' | 'timeseries';
@@ -10,6 +11,11 @@ export interface OnSelectNodeTreeParams {
   node?: Node;
 }
 
+export interface OnRightClickNodeTreeParams {
+  event: React.MouseEvent<any>;
+  node: AntTreeNodeProps;
+}
+
 export interface NodeTreeStyles {
   list?: React.CSSProperties;
 }
@@ -18,6 +24,7 @@ export interface NodeTreeProps {
   modelId: number;
   revisionId: number;
   onSelect?: (onSelect: OnSelectNodeTreeParams) => void;
+  onRightClick?: (event: OnRightClickNodeTreeParams) => void;
   defaultExpandedKeys?: number[];
   styles?: NodeTreeStyles;
   theme?: AnyIfEmpty<{}>;


### PR DESCRIPTION
Added onRightClick property to 3DNodeTree component. Users can customize behaviors when a tree node is right clicked by specifying this property.