### PR TITLE
docs(readme): fix logo markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-<a href="https://cognite.com/">
-    <img src="https://github.com/cognitedata/gearbox.js/raw/master/cognite_logo.png" alt="Cognite logo" title="Cognite" align="right" height="80" />
-</a>
+<a href="https://cognite.com/"><img src="https://github.com/cognitedata/gearbox.js/raw/master/cognite_logo.png" alt="Cognite logo" title="Cognite" align="right" height="80" /></a>
 
 Gearbox.js
 ==========================


### PR DESCRIPTION
spaces break indentations on vuepress for some reason