### PR TITLE
SVGViewer positioning fix

### DIFF
--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -17,6 +17,7 @@ import { getDocumentDownloadLink } from './utils';
 const zoomLevel = 0.7;
 const wheelZoomLevel = 0.15;
 const currentAssetClassName = 'current-asset';
+const minDesktopWidth = 992;
 
 export interface SvgViewerProps {
   // CDF fileId to fetch svg-document
@@ -113,7 +114,7 @@ export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
 
   render() {
     const { title, description, customClassNames = {} } = this.props;
-    const isDesktop = this.state.width > 992;
+    const isDesktop = this.state.width > minDesktopWidth;
 
     return (
       <SVGViewerContainer
@@ -141,6 +142,7 @@ export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
           customClassNames={customClassNames}
           data-test-id="svg-viewer"
         >
+          {/* show header if it's desktop or search is hidden for mobiles */}
           {(isDesktop || !this.state.isSearchVisible) && (
             <StyledHeaderContainer>
               <MobileModalClose
@@ -201,6 +203,7 @@ export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
             searchClassName={customClassNames.searchResults}
             currentSearchClassName={customClassNames.currentSearchResult}
           />
+          {/* move pinchZoomContainer if search is visible on mobile */}
           <div
             ref={this.pinchZoomContainer}
             style={
@@ -490,7 +493,7 @@ export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
   };
 
   zoomOnCurrentAsset = (currentAsset: Element | null) => {
-    const isDesktop = this.state.width > 992;
+    const isDesktop = this.state.width > minDesktopWidth;
     if (!currentAsset || !this.pinchZoomInstance.container) {
       return;
     }
@@ -563,7 +566,7 @@ export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
   };
 
   onContainerClick = () => {
-    const isDesktop = this.state.width > 992;
+    const isDesktop = this.state.width > minDesktopWidth;
     if (isDesktop && this.inputWrapper.current) {
       this.inputWrapper.current.focus();
     }

--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -120,13 +120,15 @@ export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
         onClick={this.onContainerClick}
         onKeyDown={this.handleKeyDown}
       >
-        <input
-          type="text"
-          onBlur={this.onContainerBlur}
-          onFocus={this.onContainerFocus}
-          ref={this.inputWrapper}
-          style={{ opacity: 0, position: 'absolute', pointerEvents: 'none' }}
-        />
+        {isDesktop && (
+          <input
+            type="text"
+            onBlur={this.onContainerBlur}
+            onFocus={this.onContainerFocus}
+            ref={this.inputWrapper}
+            style={{ opacity: 0, position: 'absolute', pointerEvents: 'none' }}
+          />
+        )}
         <SvgNode
           ref={this.svgParentNode}
           onMouseDown={this.onMouseDown}
@@ -139,46 +141,50 @@ export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
           customClassNames={customClassNames}
           data-test-id="svg-viewer"
         >
-          <StyledHeaderContainer>
-            <MobileModalClose
-              data-test-id="close-svgviewer-btn"
-              onClick={this.handleCloseModal}
-            >
-              <Icon type="arrow-left" />
-            </MobileModalClose>
-            <StyledHeaderTitle>
-              {title && <StyledFileName>{title}</StyledFileName>}
-              {description && (
-                <StyledHeaderDescription>{description}</StyledHeaderDescription>
-              )}
-            </StyledHeaderTitle>
-            <StyledHeaderButtonsContainer>
-              <ModalButton
-                onClick={this.zoomIn}
-                data-test-id="zoom-in-svgviewer"
-              >
-                <CustomIcon.ZoomIn />
-              </ModalButton>
-              <ModalButton
-                onClick={this.zoomOut}
-                data-test-id="zoom-out-svgviewer"
-              >
-                <CustomIcon.ZoomOut />
-              </ModalButton>
-              <ModalButton
-                onClick={this.openSearch}
-                data-test-id="search-button-svgviewer"
-              >
-                <CustomIcon.FindInPage />
-              </ModalButton>
-              <CloseModalButton
-                onClick={this.handleCloseModal}
+          {(isDesktop || !this.state.isSearchVisible) && (
+            <StyledHeaderContainer>
+              <MobileModalClose
                 data-test-id="close-svgviewer-btn"
+                onClick={this.handleCloseModal}
               >
-                <CustomIcon.Close />
-              </CloseModalButton>
-            </StyledHeaderButtonsContainer>
-          </StyledHeaderContainer>
+                <Icon type="arrow-left" />
+              </MobileModalClose>
+              <StyledHeaderTitle>
+                {title && <StyledFileName>{title}</StyledFileName>}
+                {description && (
+                  <StyledHeaderDescription>
+                    {description}
+                  </StyledHeaderDescription>
+                )}
+              </StyledHeaderTitle>
+              <StyledHeaderButtonsContainer>
+                <ModalButton
+                  onClick={this.zoomIn}
+                  data-test-id="zoom-in-svgviewer"
+                >
+                  <CustomIcon.ZoomIn />
+                </ModalButton>
+                <ModalButton
+                  onClick={this.zoomOut}
+                  data-test-id="zoom-out-svgviewer"
+                >
+                  <CustomIcon.ZoomOut />
+                </ModalButton>
+                <ModalButton
+                  onClick={this.openSearch}
+                  data-test-id="search-button-svgviewer"
+                >
+                  <CustomIcon.FindInPage />
+                </ModalButton>
+                <CloseModalButton
+                  onClick={this.handleCloseModal}
+                  data-test-id="close-svgviewer-btn"
+                >
+                  <CustomIcon.Close />
+                </CloseModalButton>
+              </StyledHeaderButtonsContainer>
+            </StyledHeaderContainer>
+          )}
           <SVGViewerSearch
             visible={this.state.isSearchVisible}
             svg={this.svg}
@@ -195,7 +201,14 @@ export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
             searchClassName={customClassNames.searchResults}
             currentSearchClassName={customClassNames.currentSearchResult}
           />
-          <div ref={this.pinchZoomContainer}>
+          <div
+            ref={this.pinchZoomContainer}
+            style={
+              !isDesktop && this.state.isSearchVisible
+                ? { top: '65px', position: 'relative' }
+                : {}
+            }
+          >
             <div
               ref={this.pinchZoom}
               onTouchStart={this.onTouchStart}
@@ -550,7 +563,8 @@ export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
   };
 
   onContainerClick = () => {
-    if (this.inputWrapper.current) {
+    const isDesktop = this.state.width > 992;
+    if (isDesktop && this.inputWrapper.current) {
       this.inputWrapper.current.focus();
     }
   };
@@ -765,6 +779,9 @@ const MobileModalClose = styled(ModalButton)`
 `;
 
 const ModalMobileFooter = styled.div`
+  position: absolute;
+  bottom: 0;
+  left: 0;
   width: 100%;
   height: 65px;
   display: flex;


### PR DESCRIPTION
For mobile devices positioning of the viewer was calculated incorrectly.
+ input for ctrl-f was on focus on mobile which led to the keyboard stayed opened so now we just don't render it for mobile devices.