### PR TITLE
Set unknown tenant validity on avanced opt change

### DIFF
--- a/src/components/TenantSelector/TenantSelector.tsx
+++ b/src/components/TenantSelector/TenantSelector.tsx
@@ -184,6 +184,7 @@ class TenantSelector extends React.Component<
 
     this.setState({
       advanced,
+      validity: TenantValidity.UNKNOWN,
     });
   }
 


### PR DESCRIPTION
Reset the validity of the tenant whenever the advanced options change.

We use advanced options to set the cluster, this means that a tenant could be valid for a different cluster. 
The current behaviour was that the form stayed invalid even if you changed the cluster.
https://cognitedata.atlassian.net/browse/CO-848?atlOrigin=eyJpIjoiY2Q5NDNmYjMyMTI1NDgxY2JjODVmNGVlMDE1NGMzNzAiLCJwIjoiaiJ9
