### PR TITLE
fix: AssetTree - Add query for fetching root data

### DIFF
--- a/src/components/AssetTree/AssetTree.tsx
+++ b/src/components/AssetTree/AssetTree.tsx
@@ -103,7 +103,9 @@ class AssetTree extends React.Component<AssetTreeProps, AssetTreeState> {
       console.error(ERROR_NO_SDK_CLIENT);
       return;
     }
-    const assets = await this.context.assets.list().autoPagingToArray();
+    const assets = await this.context.assets
+      .list({ filter: { root: true } })
+      .autoPagingToArray();
     this.setState({
       assets,
       treeData:


### PR DESCRIPTION
Add `{filter: { root: true } }` to the `asset.list()` call to actually
fetch assets under the root node in the AssetTree component's
`componentDidMount()` method. This seems to have been omitted when
updating to SDK v1.