### PR TITLE
Feat/configurable asset tree length delimiter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/gearbox",
-  "version": "1.0.2",
+  "version": "1.1.2",
   "description": "GearBox will be a place for application developers to contribute useful, reusable components across applications",
   "contributors": [],
   "main": "dist/index.js",

--- a/src/components/AssetTree/AssetTree.tsx
+++ b/src/components/AssetTree/AssetTree.tsx
@@ -34,6 +34,10 @@ interface AssetTreeState {
   expandedKeys: ExpandedKeysMap;
 }
 
+interface AutoPagingToArrayOptions {
+  limit?: number;
+}
+
 class AssetTree extends React.Component<AssetTreeProps, AssetTreeState> {
   static contextType = ClientSDKContext;
   static defaultProps = {
@@ -86,6 +90,11 @@ class AssetTree extends React.Component<AssetTreeProps, AssetTreeState> {
   }
   context!: React.ContextType<typeof ClientSDKContext>;
 
+  autoPagingToArrayOptions: AutoPagingToArrayOptions = this.props
+    .autoPagingToArrayOptions
+    ? this.props.autoPagingToArrayOptions
+    : { limit: 25 };
+
   constructor(props: AssetTreeProps) {
     super(props);
     const { defaultExpandedKeys } = props;
@@ -105,7 +114,7 @@ class AssetTree extends React.Component<AssetTreeProps, AssetTreeState> {
     }
     const assets = await this.context.assets
       .list({ filter: { root: true } })
-      .autoPagingToArray();
+      .autoPagingToArray(this.autoPagingToArrayOptions);
     this.setState({
       assets,
       treeData:
@@ -116,7 +125,7 @@ class AssetTree extends React.Component<AssetTreeProps, AssetTreeState> {
   cursorApiRequest = async (assetId: number): Promise<Asset[]> => {
     const result = await this.context!.assets.list({
       filter: { parentIds: [assetId] },
-    }).autoPagingToArray();
+    }).autoPagingToArray(this.autoPagingToArrayOptions);
     if (!result || !Array.isArray(result)) {
       console.error(ERROR_API_UNEXPECTED_RESULTS);
     }

--- a/src/interfaces/AssetTypes.ts
+++ b/src/interfaces/AssetTypes.ts
@@ -1,4 +1,4 @@
-import { Asset } from '@cognite/sdk';
+import { Asset, AutoPagingToArrayOptions } from '@cognite/sdk';
 import { AnyIfEmpty } from '../interfaces';
 import { MetadataId } from './index';
 
@@ -67,6 +67,7 @@ export interface AssetTreeProps {
   defaultExpandedKeys?: number[];
   styles?: AssetTreeStyles;
   theme?: AnyIfEmpty<{}>;
+  autoPagingToArrayOptions?: AutoPagingToArrayOptions;
 }
 
 export interface AdvancedSearch {


### PR DESCRIPTION
This allows us to override the default 25 asset limit in the SDK when
fetching sub-assets in the view, by passing an optional
`autoPagingToArrayOption` prop with an `{ limit: 123 }` object.

This added flexibility might come at the cost of performance if one
passes large limits, or if one uses the supported `-1` that lists
however many entries are in the sub-tree.

The need for this arose when assets in the tree in our project suddenly were missing. As no props are passed to the sdk as of today the default limit of 25 is invoked. This allows us to modify this at will. 

Minor version bump as this is a new feature as far as I know. 