### PR TITLE
Feat/10 year timeseries meta

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/gearbox",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "GearBox will be a place for application developers to contribute useful, reusable components across applications",
   "contributors": [],
   "main": "dist/index.js",

--- a/src/components/TimeseriesChartMeta/TimeseriesChartMetaPure.test.tsx
+++ b/src/components/TimeseriesChartMeta/TimeseriesChartMetaPure.test.tsx
@@ -105,7 +105,7 @@ describe('TimeseriesChartMeta', () => {
     radioInputs.first().simulate('change', { target: { checked: true } });
     const checkedLabel = wrapper.find(activeLabelSelector);
     expect(checkedLabel).toHaveLength(1);
-    expect(checkedLabel.text()).toEqual('1 year');
+    expect(checkedLabel.text()).toEqual('10 years');
   });
 
   it('Should render nothing if timeseries is null or undefined', () => {

--- a/src/components/TimeseriesChartMeta/TimeseriesChartMetaPure.tsx
+++ b/src/components/TimeseriesChartMeta/TimeseriesChartMetaPure.tsx
@@ -8,6 +8,10 @@ import { TimeseriesMetaInfo } from './components/TimeseriesMetaInfo';
 import { TimeseriesValue } from './components/TimeseriesValue';
 
 const timeScales: { [key: string]: { unit: string; number: number } } = {
+  last10Years: {
+    unit: 'years',
+    number: 10,
+  },
   lastYear: {
     unit: 'year',
     number: 1,


### PR DESCRIPTION
This is a requested addition for our use case as our analysts will look at data as far back as this. Yes, zooming out is an option, and later on we will probably have custom zoom levels anyway, but it's a nice addition for now. 

The version bump might seem drastic, but as it's technically a new feature it follows semantic versioning. 