### PR TITLE
feat(asset tree): don't show "expand" arrow on childless assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@babel/preset-env": "^7.3.1",
     "@babel/preset-react": "^7.0.0",
     "@cognite/griff-react": "^0.4.2",
-    "@cognite/sdk": "^2.2.1",
+    "@cognite/sdk": "^2.7.0",
     "@commitlint/cli": "^8.2.0",
     "@commitlint/config-conventional": "^8.2.0",
     "@semantic-release/changelog": "^3.0.4",

--- a/src/components/AssetTree/AssetTree.test.tsx
+++ b/src/components/AssetTree/AssetTree.test.tsx
@@ -1,3 +1,4 @@
+import { Tree } from 'antd';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
@@ -67,6 +68,30 @@ describe('AssetTree', () => {
       expect(Object.keys(jestTest.mock.calls[0][0]).sort()).toEqual(
         ['node', 'key', 'isLeaf', 'title'].sort()
       );
+      done();
+    });
+  });
+
+  it("Don't show expand arrows if child count > 0", done => {
+    const AssetTreeModal = mount(
+      <ClientSDKProvider client={sdk}>
+        <AssetTree />
+      </ClientSDKProvider>
+    );
+    setImmediate(() => {
+      AssetTreeModal.update();
+
+      expect(
+        AssetTreeModal.find(Tree.TreeNode)
+          .map(node => node.props())
+          .map(({ eventKey, isLeaf }) => ({ id: Number(eventKey), isLeaf }))
+      ).toEqual(
+        ASSET_ZERO_DEPTH_ARRAY.map(({ id, aggregates }) => ({
+          id,
+          isLeaf: aggregates ? !aggregates.childCount : false,
+        }))
+      );
+
       done();
     });
   });

--- a/src/components/AssetTree/AssetTree.tsx
+++ b/src/components/AssetTree/AssetTree.tsx
@@ -23,9 +23,13 @@ interface ExpandedKeysMap {
   [key: number]: true;
 }
 
+interface AssetTreeNodeMap {
+  [id: string]: AssetTreeNode;
+}
+
 interface AssetTreeState {
   rootAssetNodes: number[];
-  assetNodesMap: { [id: string]: AssetTreeNode };
+  assetNodesMap: AssetTreeNodeMap;
   expandedKeys: ExpandedKeysMap;
 }
 
@@ -45,8 +49,8 @@ class AssetTree extends React.Component<AssetTreeProps, AssetTreeState> {
     theme: { ...defaultTheme },
   };
 
-  static convertAssetsToNodeMap(assets: Asset[]) {
-    const nodes: { [id: string]: AssetTreeNode } = {};
+  static convertAssetsToNodeMap(assets: Asset[]): AssetTreeNodeMap {
+    const nodes: AssetTreeNodeMap = {};
     assets.map(AssetTree.convertToNode).forEach(node => {
       nodes[node.asset.id] = node;
     });
@@ -113,12 +117,11 @@ class AssetTree extends React.Component<AssetTreeProps, AssetTreeState> {
     if (!treeNode.props.children && assetId) {
       const updatedAssetNode = { ...this.state.assetNodesMap[assetId] };
       const assetChildren = await this.cursorApiRequest(assetId);
-      let mapUpdate: { [s: number]: AssetTreeNode };
+      const mapUpdate = AssetTree.convertAssetsToNodeMap(assetChildren);
 
       if (assetChildren.length) {
         assetChildren.sort((a, b) => a.name.localeCompare(b.name));
         updatedAssetNode.children = assetChildren.map(({ id }) => id);
-        mapUpdate = AssetTree.convertAssetsToNodeMap(assetChildren);
       } else {
         updatedAssetNode.isLeaf = true;
       }

--- a/src/components/AssetTree/__snapshots__/AssetTree.test.tsx.snap
+++ b/src/components/AssetTree/__snapshots__/AssetTree.test.tsx.snap
@@ -11,30 +11,7 @@ exports[`AssetTree renders correctly 1`] = `
     role="treeitem"
   >
     <span
-      className="ant-tree-switcher ant-tree-switcher-noop"
-    />
-    <span
-      className="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
-      onClick={[Function]}
-      onContextMenu={[Function]}
-      onDoubleClick={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      title="Aker BP: Aker BP"
-    >
-      <span
-        className="ant-tree-title"
-      >
-        Aker BP: Aker BP
-      </span>
-    </span>
-  </li>
-  <li
-    className="sc-bdVaJa fYHvCl ant-tree-treenode-switcher-close"
-    role="treeitem"
-  >
-    <span
-      className="ant-tree-switcher ant-tree-switcher_close"
+      className="ant-tree-switcher ant-tree-switcher_open"
       onClick={[Function]}
     >
       <i
@@ -58,7 +35,30 @@ exports[`AssetTree renders correctly 1`] = `
       </i>
     </span>
     <span
-      className="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
+      className="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-open"
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      title="Aker BP: Aker BP"
+    >
+      <span
+        className="ant-tree-title"
+      >
+        Aker BP: Aker BP
+      </span>
+    </span>
+  </li>
+  <li
+    className="sc-bdVaJa fYHvCl"
+    role="treeitem"
+  >
+    <span
+      className="ant-tree-switcher ant-tree-switcher-noop"
+    />
+    <span
+      className="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-normal"
       onClick={[Function]}
       onContextMenu={[Function]}
       onDoubleClick={[Function]}

--- a/src/components/AssetTree/stories/AssetTree.stories.tsx
+++ b/src/components/AssetTree/stories/AssetTree.stories.tsx
@@ -41,8 +41,9 @@ class CogniteClient extends MockCogniteClient {
           setTimeout(() => {
             if (scope && scope.filter && scope.filter.parentIds) {
               const { parentIds } = scope.filter;
-              ASSET_LIST_CHILD.sort(a => (a.id === parentIds[0] ? -1 : 1));
-              resolve(ASSET_LIST_CHILD);
+              resolve(
+                ASSET_LIST_CHILD.filter(a => a.parentId === parentIds[0])
+              );
             }
             resolve(ASSET_ZERO_DEPTH_ARRAY);
           }, 300);

--- a/src/mocks/assetsListV2.ts
+++ b/src/mocks/assetsListV2.ts
@@ -22,6 +22,7 @@ export const ASSET_ZERO_DEPTH_ARRAY: Asset[] = [
     description: 'Aker BP',
     createdTime: new Date(0),
     lastUpdatedTime: new Date(0),
+    aggregates: { childCount: 1 },
   },
   {
     id: 2675073401706610,
@@ -49,6 +50,7 @@ export const ASSET_ZERO_DEPTH_ARRAY: Asset[] = [
     },
     createdTime: new Date(1534854951557),
     lastUpdatedTime: new Date(1534854951557),
+    aggregates: { childCount: 0 },
   },
 ];
 
@@ -137,6 +139,7 @@ export const ASSET_LIST_CHILD: Asset[] = [
     },
     createdTime: new Date(0),
     lastUpdatedTime: new Date(0),
+    aggregates: { childCount: 0 },
   },
   {
     id: 5786472304680477,
@@ -310,6 +313,7 @@ export const ASSET_LIST_CHILD: Asset[] = [
       WMT_TAG_UPDATED_BY: '1001',
       WMT_TAG_UPDATED_DATE: '2015-10-08 15:05:08',
     },
+    aggregates: { childCount: 0 },
     createdTime: new Date(0),
     lastUpdatedTime: new Date(0),
   },
@@ -346,6 +350,7 @@ export const ASSET_LIST_CHILD: Asset[] = [
       WMT_TAG_UPDATED_BY: '1001',
       WMT_TAG_UPDATED_DATE: '2015-10-08 15:05:08',
     },
+    aggregates: { childCount: 0 },
     createdTime: new Date(0),
     lastUpdatedTime: new Date(0),
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -997,12 +997,12 @@
     react-select "^1.2.1"
     react-sizeme "^2.5.2"
 
-"@cognite/sdk@^2.2.1":
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/@cognite/sdk/-/sdk-2.2.2.tgz#3ac9c305c52df31ef768b44c2bade852b581362c"
-  integrity sha512-+HiCFhcXRP07xKB+1HNfsnUiWh9mjZFeucqUBAUG2IfyEMrvFDef7WngxLQ9s/goohgPJ0cCjzdQ2RsCzE218g==
+"@cognite/sdk@^2.7.0":
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/@cognite/sdk/-/sdk-2.7.0.tgz#f464d23a56743f629d2bf6337129674e2d4cf829"
+  integrity sha512-5HL2L6KHE4MZUYiCPho2vXPAvCya/yRieLaMgTofLlRAde0cC9rE1zw3jRHMkH+9/rwoWrQyT5RqRwUvRrKeKg==
   dependencies:
-    axios "0.18.1"
+    cross-fetch "^3.0.4"
     lodash "^4.17.11"
     query-string "^5.1.1"
     url "^0.11.0"
@@ -3195,14 +3195,6 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.1.tgz#ff3f0de2e7b5d180e757ad98000f1081b87bcea3"
-  integrity sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==
-  dependencies:
-    follow-redirects "1.5.10"
-    is-buffer "^2.0.2"
-
 babel-code-frame@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -4529,6 +4521,14 @@ create-react-context@^0.2.1:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
+cross-fetch@^3.0.4:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.4.tgz#7bef7020207e684a7638ef5f2f698e24d9eb283c"
+  integrity sha512-MSHgpjQqgbT/94D4CyADeNoYh52zMkCX4pcJvPP5WqPsLFMKjr2TCMg381ox5qI0ii2dPwaLx/00477knXqXVw==
+  dependencies:
+    node-fetch "2.6.0"
+    whatwg-fetch "3.0.0"
+
 cross-spawn@6.0.5, cross-spawn@^6.0.0:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -5233,13 +5233,6 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
-debug@=3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 
@@ -6310,13 +6303,6 @@ focus-lock@^0.6.3:
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.4.tgz#066af3ed5875d85745ab45ef4fbbb43e8a73514a"
   integrity sha512-+waElh6m7dbNmEabXQIblZjJMIRQOoHMNqB8RZkyemK+vN1XQ9uHLi740DVwTcK5fzAq3g+tBglLjIqUDHX/Og==
 
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
-
 for-in@^0.1.3:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-0.1.8.tgz#d8773908e31256109952b1fdb9b3fa867d2775e1"
@@ -7275,7 +7261,7 @@ is-buffer@^1.0.2, is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-buffer@^2.0.0, is-buffer@^2.0.2:
+is-buffer@^2.0.0:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-2.0.3.tgz#4ecf3fcf749cbd1e472689e109ac66261a25e725"
   integrity sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==
@@ -9179,6 +9165,11 @@ node-emoji@1.10.0:
   dependencies:
     lodash.toarray "^4.4.0"
 
+node-fetch@2.6.0, node-fetch@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
+  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
+
 node-fetch@^1.0.1:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
@@ -9186,11 +9177,6 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
-
-node-fetch@^2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
-  integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -13395,7 +13381,7 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   dependencies:
     iconv-lite "0.4.24"
 
-whatwg-fetch@>=0.10.0:
+whatwg-fetch@3.0.0, whatwg-fetch@>=0.10.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==


### PR DESCRIPTION
https://github.com/cognitedata/gearbox.js/issues/454
I also did some refactoring on component, as simply changing `isLeaf=true` didn't work.
So I started digging and realised that the structures we use are not very "reactive".
That's why I decided to use just one map "assetId => node" in the state. This makes all the state operations obvious, reactive and always top-down (not updating assetTree from bottom `node.refData.props.whatever = value`)