### PR TITLE
fix(svg viewer): fixes bug related to resizing

### DIFF
--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -321,6 +321,7 @@ export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
         tapZoomFactor: 8,
         maxZoom: 30,
         minZoom: 1,
+        setOffsetsOnce: true,
       });
     }
   };


### PR DESCRIPTION
-  **before**: while resizing component with zoomed and drugged svg image inside, image resets offset position
- **after**: svg image offset remains unchanged after component resizing

Fixes #433 