### PR TITLE
fix(asset-tree): unreachable nodes appears after changing assetIds prop few times

### DIFF
--- a/src/components/AssetTree/AssetTree.test.tsx
+++ b/src/components/AssetTree/AssetTree.test.tsx
@@ -51,20 +51,19 @@ afterEach(() => {
 });
 
 describe('AssetTree', () => {
-  // fix this afterwards
-  // it('renders correctly', done => {
-  //   const tree = renderer.create(
-  //     <ClientSDKProvider client={sdk}>
-  //       <AssetTree
-  //         defaultExpandedKeys={[ASSET_ZERO_DEPTH_ARRAY[zeroChild].id]}
-  //       />
-  //     </ClientSDKProvider>
-  //   );
-  //   setImmediate(() => {
-  //     expect(tree).toMatchSnapshot();
-  //     done();
-  //   });
-  // });
+  it('renders correctly', done => {
+    const tree = renderer.create(
+      <ClientSDKProvider client={sdk}>
+        <AssetTree
+          defaultExpandedKeys={[ASSET_ZERO_DEPTH_ARRAY[zeroChild].id]}
+        />
+      </ClientSDKProvider>
+    );
+    setImmediate(() => {
+      expect(tree).toMatchSnapshot();
+      done();
+    });
+  });
 
   it('renders correctly with assetIds', done => {
     const tree = renderer.create(
@@ -119,7 +118,7 @@ describe('AssetTree', () => {
 
     await sleep(0);
     AssetTreeModal.update();
-    expect(sdk.assets.list).toBeCalledTimes(2);
+    expect(sdk.assets.list).toBeCalledTimes(3);
     expect(
       AssetTreeModal.find(Tree.TreeNode)
         .map(node => node.props())

--- a/src/components/AssetTree/AssetTree.test.tsx
+++ b/src/components/AssetTree/AssetTree.test.tsx
@@ -3,7 +3,9 @@ import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';
 import renderer from 'react-test-renderer';
+import { sleep } from '../../mocks';
 import {
+  ASSET_LIST_CHILD,
   ASSET_TREE_STYLES,
   ASSET_ZERO_DEPTH_ARRAY,
 } from '../../mocks/assetsListV2';
@@ -27,10 +29,21 @@ const sdk = new CogniteClient({ appId: 'gearbox test' });
 configure({ adapter: new Adapter() });
 
 beforeEach(() => {
-  sdk.assets.list.mockReturnValue({
-    autoPagingToArray: async () => ASSET_ZERO_DEPTH_ARRAY,
+  sdk.assets.list.mockImplementation(({ filter: { parentIds } }: any) => ({
+    autoPagingToArray: async () => {
+      if (parentIds) {
+        return ASSET_LIST_CHILD.filter(({ parentId }) =>
+          parentIds.includes(parentId)
+        );
+      } else {
+        return ASSET_ZERO_DEPTH_ARRAY;
+      }
+    },
+  }));
+  sdk.assets.retrieve.mockImplementation((ids: { id: number }[]) => {
+    const idsToFind = ids.map(({ id }) => id);
+    return ASSET_LIST_CHILD.filter(({ id }) => idsToFind.includes(id));
   });
-  sdk.assets.retrieve.mockReturnValue([ASSET_ZERO_DEPTH_ARRAY[0]]);
 });
 
 afterEach(() => {
@@ -38,19 +51,20 @@ afterEach(() => {
 });
 
 describe('AssetTree', () => {
-  it('renders correctly', done => {
-    const tree = renderer.create(
-      <ClientSDKProvider client={sdk}>
-        <AssetTree
-          defaultExpandedKeys={[ASSET_ZERO_DEPTH_ARRAY[zeroChild].id]}
-        />
-      </ClientSDKProvider>
-    );
-    setImmediate(() => {
-      expect(tree).toMatchSnapshot();
-      done();
-    });
-  });
+  // fix this afterwards
+  // it('renders correctly', done => {
+  //   const tree = renderer.create(
+  //     <ClientSDKProvider client={sdk}>
+  //       <AssetTree
+  //         defaultExpandedKeys={[ASSET_ZERO_DEPTH_ARRAY[zeroChild].id]}
+  //       />
+  //     </ClientSDKProvider>
+  //   );
+  //   setImmediate(() => {
+  //     expect(tree).toMatchSnapshot();
+  //     done();
+  //   });
+  // });
 
   it('renders correctly with assetIds', done => {
     const tree = renderer.create(
@@ -62,6 +76,56 @@ describe('AssetTree', () => {
       expect(tree).toMatchSnapshot();
       done();
     });
+  });
+
+  it('renders correctly when assetIds property reset', async () => {
+    const AssetTreeModal = mount(
+      <ClientSDKProvider client={sdk}>
+        <AssetTree assetIds={[ASSET_ZERO_DEPTH_ARRAY[zeroChild].id]} />
+      </ClientSDKProvider>
+    );
+
+    await sleep(0);
+    AssetTreeModal.update();
+    AssetTreeModal.find('.ant-tree-switcher')
+      .first()
+      .simulate('click');
+
+    await sleep(0);
+    AssetTreeModal.update();
+    const treeNodesFirstExpanded = AssetTreeModal.find(Tree.TreeNode)
+      .map(node => node.props())
+      .map(({ eventKey }) => Number(eventKey));
+    expect(treeNodesFirstExpanded).toEqual([
+      6687602007296940,
+      4650652196144007,
+    ]);
+    expect(sdk.assets.retrieve).toBeCalledWith([{ id: 6687602007296940 }]);
+    AssetTreeModal.setProps({
+      children: <AssetTree assetIds={undefined} />,
+    });
+
+    await sleep(0);
+    AssetTreeModal.update();
+    AssetTreeModal.setProps({
+      children: <AssetTree assetIds={[ASSET_ZERO_DEPTH_ARRAY[zeroChild].id]} />,
+    });
+
+    await sleep(0);
+    AssetTreeModal.update();
+    AssetTreeModal.find('.ant-tree-switcher')
+      .first()
+      .simulate('click');
+
+    await sleep(0);
+    AssetTreeModal.update();
+    expect(sdk.assets.list).toBeCalledTimes(2);
+    expect(
+      AssetTreeModal.find(Tree.TreeNode)
+        .map(node => node.props())
+        .map(({ eventKey }) => Number(eventKey))
+    ).toEqual(treeNodesFirstExpanded);
+    expect(sdk.assets.retrieve).toBeCalledTimes(2);
   });
 
   it('Checks if onSelect is being called', done => {

--- a/src/components/AssetTree/__snapshots__/AssetTree.test.tsx.snap
+++ b/src/components/AssetTree/__snapshots__/AssetTree.test.tsx.snap
@@ -49,6 +49,56 @@ exports[`AssetTree renders correctly 1`] = `
         Aker BP: Aker BP
       </span>
     </span>
+    <ul
+      className="ant-tree-child-tree ant-tree-child-tree-open"
+      data-expanded={true}
+      role="group"
+    >
+      <li
+        className="sc-bdVaJa fYHvCl ant-tree-treenode-switcher-close"
+        role="treeitem"
+      >
+        <span
+          className="ant-tree-switcher ant-tree-switcher_close"
+          onClick={[Function]}
+        >
+          <i
+            aria-label="icon: caret-down"
+            className="anticon anticon-caret-down ant-tree-switcher-icon"
+          >
+            <svg
+              aria-hidden="true"
+              className=""
+              data-icon="caret-down"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M840.4 300H183.6c-19.7 0-30.7 20.8-18.5 35l328.4 380.8c9.4 10.9 27.5 10.9 37 0L858.9 335c12.2-14.2 1.2-35-18.5-35z"
+              />
+            </svg>
+          </i>
+        </span>
+        <span
+          className="ant-tree-node-content-wrapper ant-tree-node-content-wrapper-close"
+          onClick={[Function]}
+          onContextMenu={[Function]}
+          onDoubleClick={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          title="VAL: Valhall plattform"
+        >
+          <span
+            className="ant-tree-title"
+          >
+            VAL: Valhall plattform
+          </span>
+        </span>
+      </li>
+    </ul>
   </li>
   <li
     className="sc-bdVaJa fYHvCl"


### PR DESCRIPTION
there is a bug on asset tree: 
1. pass some array to assetIds prop
2. click on some nodes to open them up
3. pass `undefined` to assetIds (to render normal tree)
4. pass the same array as it was before
5. -> expanding will not work anymore

I wrote a test for it, but couldn't fix
(also need too fix another test, probably broke it)
