### PR TITLE
chore(usage-tracking): use proxy client in all components

### DIFF
--- a/src/components/AssetDocumentsPanel/AssetDocumentsPanel.tsx
+++ b/src/components/AssetDocumentsPanel/AssetDocumentsPanel.tsx
@@ -9,5 +9,4 @@ export type AssetDocumentsPanelProps = WithAssetFilesProps &
   MetaDocProps &
   DocumentsPanelStylesProps;
 
-DocumentTable.displayName = 'AssetDocumentsPanel';
 export const AssetDocumentsPanel = withAssetFiles(DocumentTable);

--- a/src/components/AssetDocumentsPanel/AssetDocumentsPanel.tsx
+++ b/src/components/AssetDocumentsPanel/AssetDocumentsPanel.tsx
@@ -9,4 +9,5 @@ export type AssetDocumentsPanelProps = WithAssetFilesProps &
   MetaDocProps &
   DocumentsPanelStylesProps;
 
+DocumentTable.displayName = 'AssetDocumentsPanel';
 export const AssetDocumentsPanel = withAssetFiles(DocumentTable);

--- a/src/components/AssetMeta/AssetMeta.tsx
+++ b/src/components/AssetMeta/AssetMeta.tsx
@@ -99,7 +99,7 @@ class AssetMeta extends React.Component<AssetMetaProps, AssetMetaState>
   componentDidMount() {
     // @ts-ignore
     if (!this.includesPanel('details') && this.props.assetId) {
-      this.client = this.context('AssetMeta')!;
+      this.client = this.context(Component.displayName || '')!;
       if (!this.client) {
         console.error(ERROR_NO_SDK_CLIENT);
         return;

--- a/src/components/AssetMeta/AssetMeta.tsx
+++ b/src/components/AssetMeta/AssetMeta.tsx
@@ -1,4 +1,4 @@
-import { Asset } from '@cognite/sdk';
+import { Asset, CogniteClient } from '@cognite/sdk';
 import { Tabs } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
@@ -6,7 +6,7 @@ import {
   ERROR_API_UNEXPECTED_RESULTS,
   ERROR_NO_SDK_CLIENT,
 } from '../../constants/errorMessages';
-import { ClientSDKContext } from '../../context/clientSDKContext';
+import { ClientSDKProxyContext } from '../../context/clientSDKProxyContext';
 import { withDefaultTheme } from '../../hoc/withDefaultTheme';
 import {
   AnyIfEmpty,
@@ -64,7 +64,7 @@ interface AssetMetaState {
 
 class AssetMeta extends React.Component<AssetMetaProps, AssetMetaState>
   implements ComponentWithUnmountState {
-  static contextType = ClientSDKContext;
+  static contextType = ClientSDKProxyContext;
   static defaultProps = {
     theme: { ...defaultTheme },
   };
@@ -82,7 +82,8 @@ class AssetMeta extends React.Component<AssetMetaProps, AssetMetaState>
       return null;
     }
   }
-  context!: React.ContextType<typeof ClientSDKContext>;
+  context!: React.ContextType<typeof ClientSDKProxyContext>;
+  client!: CogniteClient;
 
   isComponentUnmounted = false;
 
@@ -98,7 +99,8 @@ class AssetMeta extends React.Component<AssetMetaProps, AssetMetaState>
   componentDidMount() {
     // @ts-ignore
     if (!this.includesPanel('details') && this.props.assetId) {
-      if (!this.context) {
+      this.client = this.context('AssetMeta')!;
+      if (!this.client) {
         console.error(ERROR_NO_SDK_CLIENT);
         return;
       }
@@ -123,7 +125,7 @@ class AssetMeta extends React.Component<AssetMetaProps, AssetMetaState>
     try {
       const assets = await connectPromiseToUnmountState(
         this,
-        this.context!.assets.retrieve([{ id: assetId }])
+        this.client.assets.retrieve([{ id: assetId }])
       );
       if (!assets || assets.length !== 1) {
         console.error(ERROR_API_UNEXPECTED_RESULTS);

--- a/src/components/AssetScanner/AssetScanner.tsx
+++ b/src/components/AssetScanner/AssetScanner.tsx
@@ -94,6 +94,7 @@ export class AssetScanner extends React.Component<
   AssetScannerProps,
   AssetScannerState
 > {
+  static displayName = 'AssetScanner';
   static defaultProps = {
     ocrRequest: ocrRecognize,
     enableNotification: false,
@@ -156,7 +157,7 @@ export class AssetScanner extends React.Component<
   }
 
   componentDidMount() {
-    this.client = this.context('AssetScanner')!;
+    this.client = this.context(AssetScanner.displayName || '')!;
     if (!this.client) {
       console.error(ERROR_NO_SDK_CLIENT);
       return;

--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
 import { Asset, AssetSearchFilter } from '@cognite/sdk';
+import { CogniteClient } from '@cognite/sdk';
 import { AssetsAPI } from '@cognite/sdk/dist/src/resources/assets/assetsApi';
 import {
   ERROR_API_UNEXPECTED_RESULTS,
   ERROR_NO_SDK_CLIENT,
 } from '../../constants/errorMessages';
-import { ClientSDKContext } from '../../context/clientSDKContext';
+import { ClientSDKProxyContext } from '../../context/clientSDKProxyContext';
 
 import { ApiQuery, Callback, PureObject } from '../../interfaces';
 import { Search, SearchStyles as Styles } from '../common/Search/Search';
@@ -47,8 +48,9 @@ export class AssetSearch extends React.Component<
     showLiveSearchResults: true,
   };
 
-  static contextType = ClientSDKContext;
-  context!: React.ContextType<typeof ClientSDKContext>;
+  static contextType = ClientSDKProxyContext;
+  context!: React.ContextType<typeof ClientSDKProxyContext>;
+  client!: CogniteClient;
   assetsApi!: AssetsAPI;
 
   constructor(props: AssetSearchProps) {
@@ -66,7 +68,8 @@ export class AssetSearch extends React.Component<
       console.error(ERROR_NO_SDK_CLIENT);
       return;
     }
-    this.assetsApi = this.context.assets;
+    this.client = this.context('AssetSearch')!;
+    this.assetsApi = this.client.assets;
   }
 
   generateSearchQuery = (query: ApiQuery) => ({

--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -42,6 +42,7 @@ export class AssetSearch extends React.Component<
   AssetSearchProps,
   AssetSearchState
 > {
+  static displayName = 'AssetSearch';
   static defaultProps = {
     rootAssetSelect: false,
     advancedSearch: false,
@@ -68,7 +69,7 @@ export class AssetSearch extends React.Component<
       console.error(ERROR_NO_SDK_CLIENT);
       return;
     }
-    this.client = this.context('AssetSearch')!;
+    this.client = this.context(AssetSearch.displayName || '')!;
     this.assetsApi = this.client.assets;
   }
 

--- a/src/components/EventPreview/EventPreview.tsx
+++ b/src/components/EventPreview/EventPreview.tsx
@@ -38,6 +38,7 @@ export class EventPreview extends React.Component<
   EventPreviewProps,
   EventPreviewState
 > {
+  static displayName = 'EventPreview';
   static contextType = ClientSDKProxyContext;
   context!: React.ContextType<typeof ClientSDKProxyContext>;
   client!: CogniteClient;
@@ -52,7 +53,7 @@ export class EventPreview extends React.Component<
   }
 
   componentDidMount() {
-    this.client = this.context('EventPreview')!;
+    this.client = this.context(EventPreview.displayName || '')!;
     if (!this.client) {
       console.error(ERROR_NO_SDK_CLIENT);
       return;

--- a/src/components/EventPreview/EventPreview.tsx
+++ b/src/components/EventPreview/EventPreview.tsx
@@ -1,4 +1,4 @@
-import { CogniteEvent } from '@cognite/sdk';
+import { CogniteClient, CogniteEvent } from '@cognite/sdk';
 import { Spin } from 'antd';
 import React from 'react';
 import styled from 'styled-components';
@@ -6,7 +6,7 @@ import {
   ERROR_API_UNEXPECTED_RESULTS,
   ERROR_NO_SDK_CLIENT,
 } from '../../constants/errorMessages';
-import { ClientSDKContext } from '../../context/clientSDKContext';
+import { ClientSDKProxyContext } from '../../context/clientSDKProxyContext';
 import { PureObject } from '../../interfaces';
 import {
   EventPreviewStyles as Styles,
@@ -38,8 +38,9 @@ export class EventPreview extends React.Component<
   EventPreviewProps,
   EventPreviewState
 > {
-  static contextType = ClientSDKContext;
-  context!: React.ContextType<typeof ClientSDKContext>;
+  static contextType = ClientSDKProxyContext;
+  context!: React.ContextType<typeof ClientSDKProxyContext>;
+  client!: CogniteClient;
 
   isComponentUnmount: boolean = false;
 
@@ -51,10 +52,12 @@ export class EventPreview extends React.Component<
   }
 
   componentDidMount() {
-    if (!this.context) {
+    this.client = this.context('EventPreview')!;
+    if (!this.client) {
       console.error(ERROR_NO_SDK_CLIENT);
       return;
     }
+
     this.loadEvent();
   }
 
@@ -70,7 +73,7 @@ export class EventPreview extends React.Component<
   }
 
   async loadEvent() {
-    const events = await this.context!.events.retrieve([
+    const events = await this.client.events.retrieve([
       { id: this.props.eventId },
     ]);
     if (events.length !== 1) {

--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -72,6 +72,7 @@ interface SvgViewerState {
 }
 
 export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
+  static displayName = 'SVGViewer';
   static contextType = ClientSDKProxyContext;
   context!: React.ContextType<typeof ClientSDKProxyContext>;
   client!: CogniteClient;
@@ -101,7 +102,7 @@ export class SVGViewer extends React.Component<SvgViewerProps, SvgViewerState> {
   }
 
   componentDidMount() {
-    this.client = this.context('SVGViewer')!;
+    this.client = this.context(SVGViewer.displayName || '')!;
     if (!this.client) {
       console.error(ERROR_NO_SDK_CLIENT);
       return;

--- a/src/components/ThreeDNodeTree/ThreeDNodeTree.tsx
+++ b/src/components/ThreeDNodeTree/ThreeDNodeTree.tsx
@@ -82,7 +82,7 @@ class ThreeDNodeTree extends React.Component<NodeTreeProps, NodeTreeState> {
   }
 
   async componentDidMount() {
-    this.client = this.context('ThreeDNodeTree')!;
+    this.client = this.context(Component.displayName || '')!;
     if (!this.client) {
       console.error(ERROR_NO_SDK_CLIENT);
       return;

--- a/src/components/TimeseriesChart/TimeseriesChart.tsx
+++ b/src/components/TimeseriesChart/TimeseriesChart.tsx
@@ -1,5 +1,7 @@
+import { CogniteClient } from '@cognite/sdk';
 import React from 'react';
 import styled from 'styled-components';
+import { ClientSDKProxyContext } from '../../context/clientSDKProxyContext';
 import { DataLoader } from './dataLoader';
 
 import {
@@ -11,7 +13,6 @@ import {
 } from '@cognite/griff-react';
 import { Spin } from 'antd';
 import { ERROR_NO_SDK_CLIENT } from '../../constants/errorMessages';
-import { ClientSDKContext } from '../../context/clientSDKContext';
 import { decimalTickFormatter } from '../../utils/axisSigFix';
 import { getColorByString } from '../../utils/colors';
 import { CursorOverview } from './components/CursorOverview';
@@ -74,7 +75,8 @@ export class TimeseriesChart extends React.Component<
   TimeseriesChartProps,
   TimeseriesChartState
 > {
-  static contextType = ClientSDKContext;
+  static displayName = 'TimeseriesChart';
+  static contextType = ClientSDKProxyContext;
   static defaultProps = {
     startTime: Date.now() - 60 * 60 * 1000,
     endTime: Date.now(),
@@ -99,13 +101,13 @@ export class TimeseriesChart extends React.Component<
     },
   };
 
-  context!: React.ContextType<typeof ClientSDKContext>;
+  client!: CogniteClient;
 
   dataLoader!: DataLoader;
 
   constructor(
     props: TimeseriesChartProps,
-    context: React.ContextType<typeof ClientSDKContext>
+    context: React.ContextType<typeof ClientSDKProxyContext>
   ) {
     super(props);
     this.state = {
@@ -116,7 +118,9 @@ export class TimeseriesChart extends React.Component<
       console.error(ERROR_NO_SDK_CLIENT);
       return;
     }
-    this.dataLoader = new DataLoader(context);
+
+    this.client = context(TimeseriesChart.displayName || '')!;
+    this.dataLoader = new DataLoader(this.client);
   }
 
   onFetchData = () => {

--- a/src/components/TimeseriesChartMeta/components/TimeseriesValue.tsx
+++ b/src/components/TimeseriesChartMeta/components/TimeseriesValue.tsx
@@ -1,7 +1,8 @@
+import { CogniteClient } from '@cognite/sdk';
 import React from 'react';
 import styled from 'styled-components';
 import { ERROR_NO_SDK_CLIENT } from '../../../constants/errorMessages';
-import { ClientSDKContext } from '../../../context/clientSDKContext';
+import { ClientSDKProxyContext } from '../../../context/clientSDKProxyContext';
 import { withDefaultTheme } from '../../../hoc/withDefaultTheme';
 import { AnyIfEmpty } from '../../../interfaces';
 import { defaultTheme } from '../../../theme/defaultTheme';
@@ -28,7 +29,7 @@ interface TimeseriesValueState {
 class TimeseriesValue
   extends React.PureComponent<TimeseriesValueProps, TimeseriesValueState>
   implements ComponentWithUnmountState {
-  static contextType = ClientSDKContext;
+  static contextType = ClientSDKProxyContext;
   static defaultProps = {
     liveUpdate: true,
     timeseriesDescription: '',
@@ -37,7 +38,8 @@ class TimeseriesValue
   };
 
   isComponentUnmounted = false;
-  context!: React.ContextType<typeof ClientSDKContext>;
+  context!: React.ContextType<typeof ClientSDKProxyContext>;
+  client!: CogniteClient;
 
   state = {
     value: null,
@@ -47,7 +49,8 @@ class TimeseriesValue
   private interval: number | null = null;
 
   componentDidMount() {
-    if (!this.context) {
+    this.client = this.context(Component.displayName || '')!;
+    if (!this.client) {
       console.error(ERROR_NO_SDK_CLIENT);
       return;
     }
@@ -84,7 +87,7 @@ class TimeseriesValue
     try {
       const datapoints = await connectPromiseToUnmountState(
         this,
-        this.context!.datapoints.retrieveLatest([
+        this.client.datapoints.retrieveLatest([
           { id: this.props.timeseriesId, before: 'now' },
         ])
       );

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -18,8 +18,8 @@ import { RangePickerValue } from 'antd/lib/date-picker/interface';
 import { FormComponentProps } from 'antd/lib/form';
 import { ColProps } from 'antd/lib/grid';
 import moment, { Moment } from 'moment';
-import React, { SyntheticEvent, useContext, useEffect, useState } from 'react';
-import { ClientSDKContext } from '../../context/clientSDKContext';
+import React, { SyntheticEvent, useEffect, useState } from 'react';
+import { useCogniteContext } from '../../context/clientSDKProxyContext';
 import { withDefaultTheme } from '../../hoc/withDefaultTheme';
 import { AnyIfEmpty, PureObject } from '../../interfaces';
 import { defaultTheme } from '../../theme/defaultTheme';
@@ -144,7 +144,7 @@ const TimeseriesDataExportFC = (props: TimeseriesDataExportProps) => {
     strings = {},
     labelFormatter,
   } = props;
-  const context = useContext(ClientSDKContext);
+  const context = useCogniteContext(Component, true);
   const [limit, setLimit] = useState(cellLimit);
   const [limitHit, setLimitHit] = useState(false);
   const [loading, setLoading] = useState(false);
@@ -433,4 +433,7 @@ Wrapper.defaultProps = {
   theme: defaultTheme,
 };
 
-export const TimeseriesDataExport = withDefaultTheme(Wrapper);
+const Component = withDefaultTheme(Wrapper);
+Component.displayName = 'TimeseriesDataExport';
+
+export { Component as TimeseriesDataExport };

--- a/src/components/TimeseriesSearch/TimeseriesSearch.tsx
+++ b/src/components/TimeseriesSearch/TimeseriesSearch.tsx
@@ -1,11 +1,12 @@
 import { GetTimeSeriesMetadataDTO } from '@cognite/sdk';
+import { CogniteClient } from '@cognite/sdk';
 import { Button, Spin } from 'antd';
 import { NativeButtonProps } from 'antd/lib/button/button';
 import { debounce } from 'lodash';
 import React, { KeyboardEvent } from 'react';
 import styled from 'styled-components';
 import { ERROR_NO_SDK_CLIENT } from '../../constants/errorMessages';
-import { ClientSDKContext } from '../../context/clientSDKContext';
+import { ClientSDKProxyContext } from '../../context/clientSDKProxyContext';
 import { ApiQuery, PureObject } from '../../interfaces';
 import { DetailCheckbox } from '../common/DetailCheckbox/DetailCheckbox';
 import { defaultStrings as rootAssetSelectStrings } from '../common/RootAssetSelect/RootAssetSelect';
@@ -58,7 +59,7 @@ export class TimeseriesSearch extends React.Component<
   TimeseriesSearchProps,
   TimeseriesSearchState
 > {
-  static contextType = ClientSDKContext;
+  static contextType = ClientSDKProxyContext;
   static defaultProps = {
     selectedTimeseries: [],
     strings: {},
@@ -80,7 +81,8 @@ export class TimeseriesSearch extends React.Component<
     }
     return null;
   }
-  context!: React.ContextType<typeof ClientSDKContext>;
+  context!: React.ContextType<typeof ClientSDKProxyContext>;
+  client!: CogniteClient;
 
   constructor(props: TimeseriesSearchProps) {
     super(props);
@@ -98,14 +100,15 @@ export class TimeseriesSearch extends React.Component<
   }
 
   async componentDidMount() {
-    if (!this.context) {
+    this.client = this.context('TimeseriesSearch')!;
+    if (!this.client) {
       console.error(ERROR_NO_SDK_CLIENT);
       return;
     }
 
     const { selectedTimeseries } = this.props;
     if (selectedTimeseries && selectedTimeseries.length > 0) {
-      const timeseries = await this.context.timeseries.retrieve(
+      const timeseries = await this.client.timeseries.retrieve(
         selectedTimeseries.map(x => ({ id: x }))
       );
       this.setState({ selectedTimeseries: timeseries });
@@ -151,10 +154,10 @@ export class TimeseriesSearch extends React.Component<
       });
       return;
     }
-    if (!this.context) {
+    if (!this.client) {
       return;
     }
-    this.context.timeseries
+    this.client.timeseries
       .search({
         limit: 100,
         filter: {

--- a/src/components/TimeseriesSearch/TimeseriesSearch.tsx
+++ b/src/components/TimeseriesSearch/TimeseriesSearch.tsx
@@ -59,6 +59,7 @@ export class TimeseriesSearch extends React.Component<
   TimeseriesSearchProps,
   TimeseriesSearchState
 > {
+  static displayName = 'TimeseriesSearch';
   static contextType = ClientSDKProxyContext;
   static defaultProps = {
     selectedTimeseries: [],
@@ -100,7 +101,7 @@ export class TimeseriesSearch extends React.Component<
   }
 
   async componentDidMount() {
-    this.client = this.context('TimeseriesSearch')!;
+    this.client = this.context(TimeseriesSearch.displayName || '')!;
     if (!this.client) {
       console.error(ERROR_NO_SDK_CLIENT);
       return;

--- a/src/hoc/withAssetEvents.tsx
+++ b/src/hoc/withAssetEvents.tsx
@@ -1,4 +1,4 @@
-import { CogniteEvent, EventFilterRequest } from '@cognite/sdk';
+import { CogniteClient, CogniteEvent, EventFilterRequest } from '@cognite/sdk';
 import React from 'react';
 import { Subtract } from 'utility-types';
 import { LoadingBlock } from '../components/common/LoadingBlock/LoadingBlock';
@@ -7,7 +7,7 @@ import {
   ERROR_NO_SDK_CLIENT,
 } from '../constants/errorMessages';
 import { SDK_LIST_LIMIT } from '../constants/sdk';
-import { ClientSDKContext } from '../context/clientSDKContext';
+import { ClientSDKProxyContext } from '../context/clientSDKProxyContext';
 import {
   CanceledPromiseException,
   ComponentWithUnmountState,
@@ -40,7 +40,7 @@ export const withAssetEvents = <P extends WithAssetEventsDataProps>(
       WithAssetEventsState
     >
     implements ComponentWithUnmountState {
-    static contextType = ClientSDKContext;
+    static contextType = ClientSDKProxyContext;
 
     static getDerivedStateFromProps(
       props: P & WithAssetEventsProps,
@@ -57,7 +57,8 @@ export const withAssetEvents = <P extends WithAssetEventsDataProps>(
       return null;
     }
 
-    context!: React.ContextType<typeof ClientSDKContext>;
+    context!: React.ContextType<typeof ClientSDKProxyContext>;
+    client!: CogniteClient;
 
     isComponentUnmounted = false;
 
@@ -72,7 +73,8 @@ export const withAssetEvents = <P extends WithAssetEventsDataProps>(
     }
 
     componentDidMount() {
-      if (!this.context) {
+      this.client = this.context(WrapperComponent.displayName || '')!;
+      if (!this.client) {
         console.error(ERROR_NO_SDK_CLIENT);
         return;
       }
@@ -94,14 +96,18 @@ export const withAssetEvents = <P extends WithAssetEventsDataProps>(
         const { assetId, queryParams } = this.props;
         const events = await connectPromiseToUnmountState(
           this,
-          this.context!.events.list({
-            limit: SDK_LIST_LIMIT,
-            ...queryParams,
-            filter: {
-              ...(queryParams && queryParams.filter ? queryParams.filter : {}),
-              assetIds: [assetId],
-            },
-          }).autoPagingToArray()
+          this.client.events
+            .list({
+              limit: SDK_LIST_LIMIT,
+              ...queryParams,
+              filter: {
+                ...(queryParams && queryParams.filter
+                  ? queryParams.filter
+                  : {}),
+                assetIds: [assetId],
+              },
+            })
+            .autoPagingToArray()
         );
 
         if (!events || !Array.isArray(events)) {

--- a/src/hoc/withAssetTimeseries.tsx
+++ b/src/hoc/withAssetTimeseries.tsx
@@ -1,10 +1,17 @@
-import { GetTimeSeriesMetadataDTO, TimeseriesFilter } from '@cognite/sdk';
+import {
+  CogniteClient,
+  GetTimeSeriesMetadataDTO,
+  TimeseriesFilter,
+} from '@cognite/sdk';
 import React from 'react';
 import { Subtract } from 'utility-types';
 import { LoadingBlock } from '../components/common/LoadingBlock/LoadingBlock';
-import { ERROR_NO_SDK_CLIENT } from '../constants/errorMessages';
+import {
+  ERROR_API_UNEXPECTED_RESULTS,
+  ERROR_NO_SDK_CLIENT,
+} from '../constants/errorMessages';
 import { SDK_LIST_LIMIT } from '../constants/sdk';
-import { ClientSDKContext } from '../context/clientSDKContext';
+import { ClientSDKProxyContext } from '../context/clientSDKProxyContext';
 import {
   CanceledPromiseException,
   ComponentWithUnmountState,
@@ -39,7 +46,7 @@ export const withAssetTimeseries = <P extends WithAssetTimeseriesDataProps>(
       WithAssetTimeseriesState
     >
     implements ComponentWithUnmountState {
-    static contextType = ClientSDKContext;
+    static contextType = ClientSDKProxyContext;
 
     static getDerivedStateFromProps(
       props: P & WithAssetTimeseriesProps,
@@ -55,7 +62,8 @@ export const withAssetTimeseries = <P extends WithAssetTimeseriesDataProps>(
 
       return null;
     }
-    context!: React.ContextType<typeof ClientSDKContext>;
+    context!: React.ContextType<typeof ClientSDKProxyContext>;
+    client!: CogniteClient;
     isComponentUnmounted = false;
 
     constructor(props: P & WithAssetTimeseriesProps) {
@@ -69,6 +77,11 @@ export const withAssetTimeseries = <P extends WithAssetTimeseriesDataProps>(
     }
 
     componentDidMount() {
+      this.client = this.context(WrapperComponent.displayName || '')!;
+      if (!this.client) {
+        console.error(ERROR_NO_SDK_CLIENT);
+        return;
+      }
       this.loadAssetTimeseries();
     }
 
@@ -83,15 +96,15 @@ export const withAssetTimeseries = <P extends WithAssetTimeseriesDataProps>(
     }
 
     async loadAssetTimeseries() {
-      if (!this.context || !this.context.timeseries) {
-        console.error(ERROR_NO_SDK_CLIENT);
+      if (!this.client.timeseries) {
+        console.error(ERROR_API_UNEXPECTED_RESULTS);
         return;
       }
       try {
         const { assetId, queryParams } = this.props;
         const assetTimeseries = ((await connectPromiseToUnmountState(
           this,
-          this.context.timeseries
+          this.client.timeseries
             .list({
               limit: SDK_LIST_LIMIT,
               ...queryParams,


### PR DESCRIPTION
This PR closes #512.

| Component            | Purpose                                                      | F/C  |  |
| -------------------- | ------------------------------------------------------------ | ---- | ---- |
| AssetSearch          | Search asset by name                                         | C | ✓ |
| AssetScanner | Scan images and identifies assets by text blocks on the image | C | ✓ |
| AssetTree            | Multi-root tree visualization of assets                      | C | ✓ |
| AssetMeta            | Visualize all info on an asset in a multi-tab view         | C | ✓ |
| AssetBreadcrumb      | Breadcrub visualization of an asset's position in the hierarchy | F | ✓ |
| AssetDetailsPanel    | Two column table visualization of an asset's key details     | C | ✓ |
| AssetTimeseriesPanel | A list of timeseries associated with an asset                | C | ✓ |
| AssetDocumentsPanel  | A list of documents associated with an asset                 | C | ✓ |
| AssetEventsPanel     | Four column paginated table visualization of events associated with an asset | C | ✓ |
| TimeseriesChart      | Chart visualize of time series                           | C | ✓ |
| TimeseriesChartMeta  | Enhanced TimeseriesChart with period selection, current sensor value, and meta data | C | ✓ |
| TimeseriesDataExport | Export timeseries data in CSV format                         | F | ✓ |
| TimeseriesPreview    | Display the current sensor value for a timeseries            | F | ✓ |
| TimeseriesSearch     | Search and select time series by name                        | C | ✓ |
| EventPreview         | Display event details                                        | C | ✓ |
| SVGViewer            | View SVG asset diagrams with search/locate, zoom/pan         | C | ✓ |
| Model3DViewer        | View 3D models                                               | C | ✓ |
| ThreeDNodeTree       | Tree visualization of 3D node hierarchy                      | C | ✓ |

`C` Class component, `F` Functional component

### Change in one component

#### Previous pattern:

All Gearbox components that interact with the Cognite API does so via a `CogniteClient` object. This object is provided via React's context mechanism.

```typescript
type ClientSDKContextType = CogniteClient | null;

class AcmeWidget extends React.Component<AcmeWidgetProps, AcmeWidgetState> {
  static contextType = ClientSDKContext;
  context!: React.ContextType<typeof ClientSDKContext>;

  componentDidMount() {
    if (!this.context) {
      console.error(ERROR_NO_SDK_CLIENT);
      return;
    }
  }
}
```

Inside some components, fields of the `CogniteClient` object- which corresponds to various APIs exposed by CDF, are bound to class fields of the component in `componentDidMount`

```typescript
import { FooAPI } from '@cognite/sdk/dist/src/resources/foo/fooApi';

class AcmeWidget extends React.Component<AcmeWidgetProps, AcmeWidgetState> {
  fooApi!: FooAPI;

  componentDidMount() {
    this.fooApi = this.context.foo;
  }
}
```

#### New pattern

Instead of being a `CogniteClient` object, the context is now a function. When called with a single string argument- the component display name for usage logs,  this function returns the actual `CogniteClient` object.

So the static `contextType` property should be set to  `ClientSDKProxyContext` instead of `ClientSDKContext` 

```typescript
import { ClientSDKProxyContext } from '../../context/clientSDKProxyContext';
// import { ClientSDKContext } from '../../context/clientSDKContext';

class AcmeWidget extends React.Component<AcmeWidgetProps, AcmeWidgetState> {
  static contextType = ClientSDKProxyContext;
  context!: React.ContextType<typeof ClientSDKProxyContext>;
}
```

Then a new class field- `client`, is defined to hold a reference to the `CogniteClient` object. This is assigned in `componentDidMount` and used inside the component instead of `context` (which earlier held the reference to the `CogniteClient` object)

```typescript
class AcmeWidget extends React.Component<AcmeWidgetProps, AcmeWidgetState> {  
  static displayName = 'AcmeWidget';
  
  client!: CogniteClient;

  componentDidMount() {
    this.client = this.context(AcmeWidget.displayName || '')!;
    if (!this.client) {
      console.error(ERROR_NO_SDK_CLIENT);
      return;
   	}
  }
}
```

In some cases, the component is wrapped in another component  before being exported. In these cases, the `displayName` prop is set in the outermost component before exporting. 

```typescript
class AcmeWidget extends React.Component<AcmeWidgetProps, AcmeWidgetState> {  
  componentDidMount() {
    this.client = this.context(Component.displayName || '')!;
  }
}

const Component = someDecorators(AcmeWidget);

Component.displayName = 'AcmeWidget';
export { Component as AcmeWidget };
```

In `withFoo` style higher order components, instead of `Component.displayName` or `AcmeWidget.displayName`, `WrapperComponent.displayName` is used.

```typescript
import { ClientSDKProxyContext } from '../context/clientSDKProxyContext';

export const withFoo = <P extends WithFooDataProps>(
  WrapperComponent: React.ComponentType<P>
) =>
  class
    extends React.Component<
      Subtract<P, WithFootDataProps> & WithFooProps,
      WithFooState
    > implements ComponentWithUnmountState 
{
      
    static contextType = ClientSDKProxyContext;
    context!: React.ContextType<typeof ClientSDKProxyContext>;
    client!: CogniteClient;

    componentDidMount() {
      this.client = this.context(WrapperComponent.displayName || '')!;
      if (!this.client) {
        console.error(ERROR_NO_SDK_CLIENT);
        return;
      }
      this.loadAsset();
    }
      
};
```

In functional components (e.g. `TimeseriesPreview`, `AssetBreadcrumb`)

```typescript
const AcmeWidget: React.FC<AcmeWidgetProps> = ({
  // ...
  const context = useCogniteContext(Component, true);

	useEffect(() => {
    const fetcherFn = async () => {
      const data = await context!.api3.op4();
    }
    
    fetcherFn();
  });
})
```

For functional components that use the cached client:

```typescript
// Refer 5a10057
```

For class components that use the cached client:

```typescript
import { ClientSDKProxyContext } from '../../context/clientSDKProxyContext';

class AcmeWidget extends React.Component<AcmeWidgetProps, AcmeWidgetState> {  
  static displayName = 'AcmeWidget';
  static contextType = ClientSDKProxyContext;
  
  client!: CogniteClient;
  context: React.ContextType<typeof ClientSDKProxyContext>
  
  constructor(
    props: AcmeWidgetProps,
    context: React.ContextType<typeof ClientSDKProxyContext>
  ) {
    
    if (!context) {
      console.error(ERROR_NO_SDK_CLIENT);
      return;
    }
    this.client = context(AcmeWidget.displayName || '')!;
    
    interactWithTheApi(this.client);
  }
}
```


