### PR TITLE
style(asset-scanner): make crop background more transparent

### DIFF
--- a/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
+++ b/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
@@ -45,7 +45,7 @@ const Container = styled.div`
 
 const Item = styled.div`
   background-color: ${({ backgroundColor }: WebcamCropPlaceholderProps) =>
-    backgroundColor ? backgroundColor : 'rgba(0,0,0,0.8)'};
+    backgroundColor ? backgroundColor : 'rgba(0,0,0,0.5)'};
   color: #fff;
 `;
 


### PR DESCRIPTION
Users found it hard to use a scanner with such a dark background.
[OPSUP-369]

[OPSUP-369]: https://cognitedata.atlassian.net/browse/OPSUP-369