### PR TITLE
feat(timeseries): support strings callback function

### DIFF
--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
@@ -149,4 +149,21 @@ describe('TimeseriesChart', () => {
 
     expect(labelFormatter).toHaveBeenCalledTimes(1);
   });
+
+  it.only('should be able to customize strings via callback function', async () => {
+    await act(async () => {
+      wrapper = mountComponent({
+        ...defaultProps,
+        strings: defaultStrings => ({
+          csvDownload: defaultStrings.csvDownload + ' customized',
+        }),
+      } as TimeseriesDataExportProps);
+    });
+
+    wrapper.update();
+
+    const submitButton = wrapper.find('button[type="submit"]');
+
+    expect(submitButton.text()).toEqual('Download as CSV customized');
+  });
 });

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -11,15 +11,16 @@ import {
 } from 'antd';
 import { RangePickerValue } from 'antd/lib/date-picker/interface';
 import { FormComponentProps } from 'antd/lib/form';
+import isFunction from 'lodash/isFunction';
 import moment from 'moment';
-import React, { FC, SyntheticEvent, useEffect, useState } from 'react';
+import React, { FC, SyntheticEvent, useEffect, useMemo, useState } from 'react';
 import { useCogniteContext } from '../../context/clientSDKProxyContext';
 import { withDefaultTheme } from '../../hoc';
-import { PureObject } from '../../interfaces';
 import { defaultTheme } from '../../theme/defaultTheme';
 import { datapointsToCSV, Delimiters, downloadCSV } from '../../utils/csv';
 import { getGranularityInMS } from '../../utils/utils';
 import { ComplexString } from '../common/ComplexString/ComplexString';
+import { defaultStrings } from './constants';
 import {
   CsvParseOptions,
   FetchCSVCall,
@@ -30,24 +31,6 @@ import {
 
 type TimeseriesDataExportFormProps = TimeseriesDataExportProps &
   FormComponentProps;
-
-const defaultStrings: PureObject = {
-  title: 'Export chart data',
-  labelRange: 'Range',
-  labelGranularity: 'Label Granularity',
-  labelGranularityHelp: 'Example inputs: 15s, 1m, 5h, 2d',
-  formatTimestamp: 'Format timestamp?',
-  formatTimestampHelp: 'e.g. 2018-04-02 12:20:20',
-  delimiterLabel: 'Select delimiter',
-  delimiterHelp: 'The character that will separate your data fields',
-  csvDownload: 'Download as CSV',
-  csvDownloadInProgress: 'Download as CSV',
-  closeBtn: 'Close',
-  imageDownloadLabel: 'Image download',
-  imageDownloadBtn: 'Download as SVG',
-  cellLimitErr:
-    'You hit the limit of {{ cellLimit }} datapoints - some data may be omitted',
-};
 
 // TODO: Check tree shacking for TimeseriesDataExport component
 const { RangePicker } = DatePicker;
@@ -103,7 +86,14 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
   const [limitHit, setLimitHit] = useState(false);
   const [loading, setLoading] = useState(false);
   const [series, setSeries] = useState<GetTimeSeriesMetadataDTO[]>([]);
-  const lang = { ...defaultStrings, ...strings };
+  const lang = useMemo(
+    () => ({
+      ...defaultStrings,
+      ...(isFunction(strings) ? strings(defaultStrings) : strings),
+    }),
+    [strings]
+  );
+
   const {
     title,
     labelRange,

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -11,7 +11,7 @@ import {
 } from 'antd';
 import { RangePickerValue } from 'antd/lib/date-picker/interface';
 import { FormComponentProps } from 'antd/lib/form';
-import isFunction from 'lodash/isFunction';
+import { isFunction } from 'lodash';
 import moment from 'moment';
 import React, { FC, SyntheticEvent, useEffect, useMemo, useState } from 'react';
 import { useCogniteContext } from '../../context/clientSDKProxyContext';

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -350,12 +350,7 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
               data-test-id="alert"
               style={{ marginTop: 8 }}
               type="error"
-              message={
-                <ComplexString
-                  input={cellLimitErr as string}
-                  cellLimit={limit}
-                />
-              }
+              message={<ComplexString input={cellLimitErr} cellLimit={limit} />}
             />
           )}
         </Form.Item>

--- a/src/components/TimeseriesDataExport/constants.ts
+++ b/src/components/TimeseriesDataExport/constants.ts
@@ -1,0 +1,19 @@
+export const defaultStrings = {
+  title: 'Export chart data',
+  labelRange: 'Range',
+  labelGranularity: 'Label Granularity',
+  labelGranularityHelp: 'Example inputs: 15s, 1m, 5h, 2d',
+  formatTimestamp: 'Format timestamp?',
+  formatTimestampHelp: 'e.g. 2018-04-02 12:20:20',
+  delimiterLabel: 'Select delimiter',
+  delimiterHelp: 'The character that will separate your data fields',
+  csvDownload: 'Download as CSV',
+  csvDownloadInProgress: 'Download as CSV',
+  closeBtn: 'Close',
+  imageDownloadLabel: 'Image download',
+  imageDownloadBtn: 'Download as SVG',
+  cellLimitErr:
+    'You hit the limit of {{ cellLimit }} datapoints - some data may be omitted',
+};
+
+export type Strings = typeof defaultStrings;

--- a/src/components/TimeseriesDataExport/interfaces.ts
+++ b/src/components/TimeseriesDataExport/interfaces.ts
@@ -105,3 +105,5 @@ export interface TimeseriesDataExportProps {
    */
   theme?: AnyIfEmpty<{}>;
 }
+
+export type TimeseriesDataExportStrings = Strings;

--- a/src/components/TimeseriesDataExport/interfaces.ts
+++ b/src/components/TimeseriesDataExport/interfaces.ts
@@ -6,8 +6,9 @@ import {
 } from '@cognite/sdk';
 import { ColProps } from 'antd/lib/grid';
 import { Moment } from 'moment';
-import { AnyIfEmpty, PureObject } from '../../interfaces';
+import { AnyIfEmpty } from '../../interfaces';
 import { Delimiters, LabelFormatter } from '../../utils/csv';
+import { Strings } from './constants';
 
 export type FetchCSVCall = (
   request: DatapointsMultiQuery,
@@ -98,7 +99,7 @@ export interface TimeseriesDataExportProps {
   /**
    * Strings, that can be customized
    */
-  strings?: PureObject;
+  strings?: ((defaultStrings: Strings) => Partial<Strings>) | Partial<Strings>;
   /**
    * @ignore
    */


### PR DESCRIPTION
We would like to use this component in Insight, but we need to translate the strings. 

We would still like to re-use the `defaultStrings` for the english and instead of exporting them from `Gearbox`, pass them to the callback `strings` function.