### PR TITLE
fix(tenant-selector): remove confusing "x" on invalid tenant

### DIFF
--- a/src/components/TenantSelector/TenantSelector.tsx
+++ b/src/components/TenantSelector/TenantSelector.tsx
@@ -30,6 +30,9 @@ class TenantSelector extends Component<
   static defaultProps = {
     advancedOptions: {},
     theme: { ...defaultTheme },
+    inputBehaviorOptions: {
+      hasFeedback: true,
+    },
   };
 
   constructor(props: TenantSelectorProps) {
@@ -88,6 +91,7 @@ class TenantSelector extends Component<
       title,
       unknownMessage,
       styles,
+      inputBehaviorOptions,
     } = this.props;
 
     const { tenant, validity } = this.state;
@@ -117,7 +121,7 @@ class TenantSelector extends Component<
           </SubTitle>
         )}
         <Form onSubmit={this.checkTenantValidity}>
-          <Form.Item {...formItemProps}>
+          <Form.Item {...inputBehaviorOptions} {...formItemProps}>
             <StyledInput
               style={styles && styles.input}
               data-id="tenant-input"

--- a/src/components/TenantSelector/TenantSelector.tsx
+++ b/src/components/TenantSelector/TenantSelector.tsx
@@ -117,7 +117,7 @@ class TenantSelector extends Component<
           </SubTitle>
         )}
         <Form onSubmit={this.checkTenantValidity}>
-          <Form.Item hasFeedback={true} {...formItemProps}>
+          <Form.Item {...formItemProps}>
             <StyledInput
               style={styles && styles.input}
               data-id="tenant-input"

--- a/src/components/TenantSelector/interfaces.ts
+++ b/src/components/TenantSelector/interfaces.ts
@@ -1,3 +1,4 @@
+import { FormItemProps } from 'antd/lib/form/FormItem';
 import React, { CSSProperties } from 'react';
 import { AnyIfEmpty, PureObject } from '../../interfaces';
 
@@ -65,4 +66,8 @@ export interface TenantSelectorProps {
    * @ignore
    */
   theme?: AnyIfEmpty<{}>;
+  /**
+   * Customisable UI settings
+   */
+  inputBehaviorOptions?: Pick<FormItemProps, 'extra' | 'hasFeedback'>;
 }

--- a/src/components/TenantSelector/interfaces.ts
+++ b/src/components/TenantSelector/interfaces.ts
@@ -69,5 +69,5 @@ export interface TenantSelectorProps {
   /**
    * Customisable UI settings
    */
-  inputBehaviorOptions?: Pick<FormItemProps, 'extra' | 'hasFeedback'>;
+  inputBehaviorOptions?: Pick<FormItemProps, 'hasFeedback'>;
 }

--- a/src/components/TenantSelector/interfaces.ts
+++ b/src/components/TenantSelector/interfaces.ts
@@ -69,5 +69,5 @@ export interface TenantSelectorProps {
   /**
    * Customisable UI settings
    */
-  inputBehaviorOptions?: Pick<FormItemProps, 'hasFeedback'>;
+  inputBehaviorOptions?: Pick<FormItemProps, 'extra' | 'hasFeedback'>;
 }

--- a/src/components/TenantSelector/stories/basic.story.mdx
+++ b/src/components/TenantSelector/stories/basic.story.mdx
@@ -2,7 +2,8 @@ import { Meta, Story, Preview, Props } from '@storybook/addon-docs/blocks';
 import { TenantSelector, TenantSelectorWithoutTheme } from '../TenantSelector';
 import {
 onTenantSelected,
-validateTenantSucess,
+inputBehaviorOptions,
+validateTenantSuccess,
 validateTenantFailed,
 advancedOptionsProps,
 validateTenantForever,
@@ -127,7 +128,7 @@ See more details in `Custom Styles` example.
 ### Custom validation success
 
 ```typescript
-const validateTenantSucess = async () => true;
+const validateTenantSuccess = async () => true;
 ```
 
 <Preview>
@@ -135,7 +136,7 @@ const validateTenantSucess = async () => true;
     <TenantSelector
       title="Example app"
       onTenantSelected={onTenantSelected}
-      validateTenant={validateTenantSucess}
+      validateTenant={validateTenantSuccess}
     />
   </Story>
 </Preview>
@@ -167,6 +168,26 @@ const validateTenantFailed = async (tenant: string) => {
       onTenantSelected={onTenantSelected}
       unknownMessage="ARE YOU NUTS?!"
       validateTenant={validateTenantFailed}
+    />
+  </Story>
+</Preview>
+
+### Custom input behavior options
+
+```typescript
+const inputBehaviorOptions = {
+  hasFeedback: false,
+};
+```
+
+<Preview>
+  <Story name="Custom input behavior" >
+    <TenantSelector
+      title="Example app"
+      onTenantSelected={onTenantSelected}
+      unknownMessage="ARE YOU NUTS?!"
+      validateTenant={validateTenantFailed}
+      inputBehaviorOptions={inputBehaviorOptions}
     />
   </Story>
 </Preview>

--- a/src/components/TenantSelector/stories/basic.story.mdx
+++ b/src/components/TenantSelector/stories/basic.story.mdx
@@ -177,6 +177,7 @@ const validateTenantFailed = async (tenant: string) => {
 ```typescript
 const inputBehaviorOptions = {
   hasFeedback: false,
+  extra: 'Speak and ye shall enter',
 };
 ```
 

--- a/src/components/TenantSelector/stories/helper.tsx
+++ b/src/components/TenantSelector/stories/helper.tsx
@@ -9,7 +9,11 @@ export const validateTenantFailed = async (tenant: string) => {
   throw new Error(tenant);
 };
 
-export const validateTenantSucess = async () => true;
+export const inputBehaviorOptions = {
+  hasFeedback: false,
+};
+
+export const validateTenantSuccess = async () => true;
 
 export const validateTenantForever = () => Promise.race([]);
 

--- a/src/components/TenantSelector/stories/helper.tsx
+++ b/src/components/TenantSelector/stories/helper.tsx
@@ -11,6 +11,7 @@ export const validateTenantFailed = async (tenant: string) => {
 
 export const inputBehaviorOptions = {
   hasFeedback: false,
+  extra: 'Speak and ye shall enter',
 };
 
 export const validateTenantSuccess = async () => true;


### PR DESCRIPTION
When the tenant is invalid, the UI displays an invalid state with
- an error message
- the input box highlighted in red
- a red X inside the input box

This is antd's default behaviour but it is confusing for users that there is an X inside the input field, which does nothing. We may expect that it should be a clickable button to clear out the invalid input.

Would like to just remove it to avoid confusion.

Fixes [OPSUP-388]

[OPSUP-388]: https://cognitedata.atlassian.net/browse/OPSUP-388