### PR TITLE
refactor: show search results counter even on 0 results

### DIFF
--- a/src/components/SVGViewer/SVGViewerSearch.tsx
+++ b/src/components/SVGViewer/SVGViewerSearch.tsx
@@ -115,7 +115,7 @@ class SVGViewerSearch extends React.Component<ComponentProps, ComponentState> {
             ref={this.searchInput}
             data-test-id="search-input-svg"
           />
-          <SearchResultsCounter hidden={this.state.amountOfResults === 0}>
+          <SearchResultsCounter hidden={!this.state.searchPhrase}>
             {this.state.currentResult}/{this.state.amountOfResults}
           </SearchResultsCounter>
         </SearchInputContainer>


### PR DESCRIPTION
Made as a fix to https://cognitedata.atlassian.net/browse/OPSUP-889. 

Display 0/0 if no results are found in SVGViewer search. Hide it if input is empty. 