### PR TITLE
chore(svgviewer): improve performance for svgviewer with images

### DIFF
--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -339,10 +339,10 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
   };
 
   shouldDisableOptimization = () => {
-    // Bacause willChange optimization has a calculation cost
+    // Because willChange optimization has a calculation cost
     // we don't want to apply it for a bigger embedded into svg <image />
     // tags since it slows down the performance instead of providing
-    // a boost. Images are already heavily optimizaide by browsers
+    // a boost. Images are already heavily optimized by browsers
     // so we don't need to care much about additional optimizations.
     const metadataArray = this.svg.querySelectorAll('image');
     this.isOptimizationDisabled = metadataArray.length > 0;

--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -44,6 +44,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
   pinchZoom: React.RefObject<HTMLDivElement>;
   pinchZoomContainer: React.RefObject<HTMLDivElement>;
   svgParentNode: React.RefObject<HTMLDivElement>;
+  isOptimizationDisabled: boolean = false;
   constructor(props: SvgViewerProps) {
     super(props);
     this.state = {
@@ -262,6 +263,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
         this.initiateScale();
         this.initPinchToZoom();
         this.initAttributesForMetadataContainer();
+        this.shouldDisableOptimization();
         this.setCustomClasses();
         this.svg.addEventListener('click', this.handleItemClick);
         this.zoomOnCurrentAsset(
@@ -336,6 +338,16 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
     });
   };
 
+  shouldDisableOptimization = () => {
+    // Bacause willChange optimization has a calculation cost
+    // we don't want to apply it for a bigger embedded into svg <image />
+    // tags since it slows down the performance instead of providing
+    // a boost. Images are already heavily optimizaide by browsers
+    // so we don't need to care much about additional optimizations.
+    const metadataArray = this.svg.querySelectorAll('image');
+    this.isOptimizationDisabled = metadataArray.length > 0;
+  };
+
   onMouseDown = (event: React.MouseEvent<HTMLDivElement>) => {
     if (!this.pinchZoomInstance) {
       return;
@@ -383,7 +395,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
   // https://developer.mozilla.org/en-US/docs/Web/CSS/will-change
   // so all the items will be rendered not blurry
   onTouchStart = () => {
-    if (this.pinchZoom.current) {
+    if (this.pinchZoom.current && !this.isOptimizationDisabled) {
       // @ts-ignore 'willChange' is not a part of 'CSSStyleDeclaration'
       this.pinchZoom.current.style.willChange = 'transform';
     }
@@ -391,7 +403,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
 
   // tslint:disable-next-line no-identical-functions
   onTouchEnd = () => {
-    if (this.pinchZoom.current) {
+    if (this.pinchZoom.current && !this.isOptimizationDisabled) {
       // @ts-ignore 'willChange' is not a part of 'CSSStyleDeclaration'
       this.pinchZoom.current.style.willChange = 'auto';
     }


### PR DESCRIPTION
For quite big SVG files with embedded images (2MB+) the performance
of SVGViewer is relatively bad.

Because willChange optimization has a calculation cost
we don't want to apply it for a bigger embedded into svg <image />
tags since it slows down the performance instead of providing
a boost. Images are already heavily optimized by browsers
so we don't need to care much about additional optimizations.

before
![before](https://user-images.githubusercontent.com/38251534/77515472-deb8b800-6e78-11ea-960c-f4c81673b4a8.gif)

after
![after](https://user-images.githubusercontent.com/38251534/77515482-e1b3a880-6e78-11ea-9d84-66a109cbaaf1.gif)
