### PR TITLE
refactor: do not import from internal sdk modules

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -31,6 +31,7 @@
       "@typescript-eslint/no-non-null-assertion": "off",
       "@typescript-eslint/ban-ts-comment": "off",
       "react/prop-types": "off",
-      "@typescript-eslint/no-unused-vars": "off"
+      "@typescript-eslint/no-unused-vars": "off",
+      "no-restricted-imports": ["error", { "patterns": ["@cognite/sdk/**"] }]
     }
 }

--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 
 import { Asset, AssetSearchFilter } from '@cognite/sdk';
 import { CogniteClient } from '@cognite/sdk';
-import { AssetsAPI } from '@cognite/sdk/dist/src/resources/assets/assetsApi';
 import {
   ERROR_API_UNEXPECTED_RESULTS,
   ERROR_NO_SDK_CLIENT,
@@ -34,7 +33,7 @@ export class AssetSearch extends Component<AssetSearchProps, AssetSearchState> {
   static contextType = ClientSDKProxyContext;
   context!: React.ContextType<typeof ClientSDKProxyContext>;
   client!: CogniteClient;
-  assetsApi!: AssetsAPI;
+  assetsApi!: CogniteClient['assets'];
 
   constructor(props: AssetSearchProps) {
     super(props);

--- a/src/components/AssetTimeseriesPanel/stories/helper.tsx
+++ b/src/components/AssetTimeseriesPanel/stories/helper.tsx
@@ -1,5 +1,5 @@
 import { GetTimeSeriesMetadataDTO } from '@cognite/sdk';
-import { CogniteAsyncIterator } from '@cognite/sdk/dist/src/autoPagination';
+import { CogniteAsyncIterator } from '@cognite/sdk';
 import React, { FC } from 'react';
 import {
   MockDatapointsClientObject,

--- a/src/components/AssetTree/interfaces.ts
+++ b/src/components/AssetTree/interfaces.ts
@@ -1,5 +1,4 @@
-import { Asset } from '@cognite/sdk';
-import { AutoPagingToArrayOptions } from '@cognite/sdk/dist/src/autoPagination';
+import { Asset, Limit } from '@cognite/sdk';
 import { Theme } from '../../interfaces';
 
 export interface AssetTreeStyles {
@@ -44,5 +43,5 @@ export interface AssetTreeProps {
    */
   theme?: Theme;
 
-  autoPagingToArrayOptions?: AutoPagingToArrayOptions;
+  autoPagingToArrayOptions?: Limit;
 }

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -6,7 +6,7 @@ import {
 import {
   DatapointsGetAggregateDatapoint,
   GetDatapointMetadata,
-} from '@cognite/sdk/dist/src/types/types';
+} from '@cognite/sdk';
 import { Button, Checkbox, DatePicker, Form, Input, Modal, Radio } from 'antd';
 import { FormComponentProps } from 'antd/lib/form';
 import { chunk, isFunction, range } from 'lodash';


### PR DESCRIPTION
we shouldn't import from internal sdk modules as it's dangerous in regards of backward compatibility 