### PR TITLE
style: add copyright header lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -22,7 +22,8 @@
     "plugins": [
         "@typescript-eslint",
         "prettier",
-        "react"
+        "react",
+        "header"
     ],
     "rules": {
       "@typescript-eslint/explicit-module-boundary-types": "off",
@@ -33,5 +34,16 @@
       "react/prop-types": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "no-restricted-imports": ["error", { "patterns": ["@cognite/sdk/**"] }]
-    }
+    },
+    "overrides": [{
+      "files": ["src/**"],
+      "rules": {
+          "header/header": ["error", "line",
+              [{
+                  "pattern": " Copyright \\d{4} Cognite AS",
+                  "template": " Copyright 2020 Cognite AS"
+              }]
+          ]
+      }
+  }]
 }

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "es-check": "^5.0.0",
     "eslint": "^7.1.0",
     "eslint-config-prettier": "^6.11.0",
+    "eslint-plugin-header": "^3.0.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.20.0",
     "husky": "^3.0.5",

--- a/src/@types/globals/index.d.ts
+++ b/src/@types/globals/index.d.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 declare module 'react-odometerjs';
 declare module 'react-sizeme';
 declare module 'numeral';

--- a/src/@types/griff-react/index.d.ts
+++ b/src/@types/griff-react/index.d.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 declare module '@cognite/griff-react' {
   import { GetAggregateDatapoint, GetDoubleDatapoint } from '@cognite/sdk';
   import { Component } from 'react';

--- a/src/@types/pinch-zoom-js/index.d.ts
+++ b/src/@types/pinch-zoom-js/index.d.ts
@@ -1,1 +1,2 @@
+// Copyright 2020 Cognite AS
 declare module 'pinch-zoom-js';

--- a/src/@types/readme/index.d.ts
+++ b/src/@types/readme/index.d.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 declare module '*.md' {
   const value: string;
   export default value;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,1 +1,2 @@
+// Copyright 2020 Cognite AS
 export * from './ocr';

--- a/src/api/ocr.ts
+++ b/src/api/ocr.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { OcrRequest } from '../components/AssetScanner/interfaces';
 import { extractValidStrings } from '../utils/utils';
 

--- a/src/cache/ClientSDKCache.ts
+++ b/src/cache/ClientSDKCache.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import {
   ClientSDKCacheAssets,

--- a/src/cache/cache.test.ts
+++ b/src/cache/cache.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset } from '@cognite/sdk';
 import { MockCogniteClient, singleTimeseries } from '../mocks';
 import { CacheAssets } from './resources/CacheAssets';

--- a/src/cache/resources/CacheAssets.ts
+++ b/src/cache/resources/CacheAssets.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   AssetList,
   CogniteClient,

--- a/src/cache/resources/CacheBase.ts
+++ b/src/cache/resources/CacheBase.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export class CacheBase {
   private requests: { [name: string]: Map<string, Promise<any>> } = {};
   private responses: { [name: string]: Map<any, any> } = {};

--- a/src/cache/resources/CacheTimeseries.ts
+++ b/src/cache/resources/CacheTimeseries.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   CogniteClient,
   ExternalId,

--- a/src/components/AssetBreadcrumb/AssetBreadcrumb.test.tsx
+++ b/src/components/AssetBreadcrumb/AssetBreadcrumb.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Breadcrumb } from 'antd';
 import { configure, mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/AssetBreadcrumb/AssetBreadcrumb.tsx
+++ b/src/components/AssetBreadcrumb/AssetBreadcrumb.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset } from '@cognite/sdk';
 import { Breadcrumb, Icon } from 'antd';
 import React, { FC, useEffect, useState } from 'react';

--- a/src/components/AssetBreadcrumb/index.ts
+++ b/src/components/AssetBreadcrumb/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './AssetBreadcrumb';
 export * from './interfaces';

--- a/src/components/AssetBreadcrumb/interfaces.ts
+++ b/src/components/AssetBreadcrumb/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset, CogniteInternalId } from '@cognite/sdk';
 
 export type FetchAssetCall = (assetId: CogniteInternalId) => Promise<Asset>;

--- a/src/components/AssetBreadcrumb/stories/helper.tsx
+++ b/src/components/AssetBreadcrumb/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset, CogniteInternalId } from '@cognite/sdk';
 import React, { FC } from 'react';
 import {

--- a/src/components/AssetDetailsPanel/AssetDetailsPanel.test.tsx
+++ b/src/components/AssetDetailsPanel/AssetDetailsPanel.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/AssetDetailsPanel/AssetDetailsPanel.tsx
+++ b/src/components/AssetDetailsPanel/AssetDetailsPanel.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { withAsset } from '../../hoc';
 import { AssetDetailsPanelPure } from './AssetDetailsPanelPure';
 import { AssetDetailsPanelPureProps } from './interfaces';

--- a/src/components/AssetDetailsPanel/AssetDetailsPanelPure.tsx
+++ b/src/components/AssetDetailsPanel/AssetDetailsPanelPure.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React, { FC } from 'react';
 import { DescriptionList } from '../DescriptionList';
 import { AssetDetailsPanelPureProps } from './interfaces';

--- a/src/components/AssetDetailsPanel/index.ts
+++ b/src/components/AssetDetailsPanel/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './AssetDetailsPanel';
 export * from './interfaces';

--- a/src/components/AssetDetailsPanel/interfaces.ts
+++ b/src/components/AssetDetailsPanel/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CSSProperties } from 'react';
 import { WithAssetDataProps, WithAssetProps } from '../../hoc';
 import { MetaDescriptionListProps } from '../DescriptionList';

--- a/src/components/AssetDetailsPanel/stories/helper.tsx
+++ b/src/components/AssetDetailsPanel/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset } from '@cognite/sdk';
 import React, { FC } from 'react';
 import { fakeAsset, MockCogniteClient } from '../../../mocks';

--- a/src/components/AssetDocumentsPanel/AssetDocumentsPanel.test.tsx
+++ b/src/components/AssetDocumentsPanel/AssetDocumentsPanel.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/AssetDocumentsPanel/AssetDocumentsPanel.tsx
+++ b/src/components/AssetDocumentsPanel/AssetDocumentsPanel.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { withAssetFiles } from '../../hoc';
 import { DocumentTable } from './DocumentTable/DocumentTable';
 import { DocumentTableProps } from './interfaces';

--- a/src/components/AssetDocumentsPanel/DocumentTable/DocumentTable.test.tsx
+++ b/src/components/AssetDocumentsPanel/DocumentTable/DocumentTable.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/AssetDocumentsPanel/DocumentTable/DocumentTable.tsx
+++ b/src/components/AssetDocumentsPanel/DocumentTable/DocumentTable.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Collapse } from 'antd';
 import React from 'react';
 import styled from 'styled-components';

--- a/src/components/AssetDocumentsPanel/DocumentTable/index.ts
+++ b/src/components/AssetDocumentsPanel/DocumentTable/index.ts
@@ -1,1 +1,2 @@
+// Copyright 2020 Cognite AS
 export { DocumentTable } from './DocumentTable';

--- a/src/components/AssetDocumentsPanel/index.ts
+++ b/src/components/AssetDocumentsPanel/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './AssetDocumentsPanel';
 export * from './interfaces';

--- a/src/components/AssetDocumentsPanel/interfaces.ts
+++ b/src/components/AssetDocumentsPanel/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { FilesMetadata } from '@cognite/sdk';
 import { CollapseProps } from 'antd/lib/collapse';
 import { CSSProperties, ReactNode } from 'react';

--- a/src/components/AssetDocumentsPanel/stories/helper.tsx
+++ b/src/components/AssetDocumentsPanel/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { FilesMetadata } from '@cognite/sdk';
 import React, { FC } from 'react';
 import { DOCUMENTS, MockCogniteClient, sleep } from '../../../mocks';

--- a/src/components/AssetEventsPanel/AssetEventsPanel.test.tsx
+++ b/src/components/AssetEventsPanel/AssetEventsPanel.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/AssetEventsPanel/AssetEventsPanel.tsx
+++ b/src/components/AssetEventsPanel/AssetEventsPanel.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { withAssetEvents } from '../../hoc';
 import { AssetEventsPanelPure } from './components/AssetEventsPanelPure';
 import { AssetEventsPanelPropsPure } from './interfaces';

--- a/src/components/AssetEventsPanel/components/AssetEventsPanelPure.test.tsx
+++ b/src/components/AssetEventsPanel/components/AssetEventsPanelPure.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteEvent } from '@cognite/sdk';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/AssetEventsPanel/components/AssetEventsPanelPure.tsx
+++ b/src/components/AssetEventsPanel/components/AssetEventsPanelPure.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteEvent } from '@cognite/sdk';
 import { Icon, Modal, Table } from 'antd';
 import React from 'react';

--- a/src/components/AssetEventsPanel/index.ts
+++ b/src/components/AssetEventsPanel/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './AssetEventsPanel';
 export * from './interfaces';

--- a/src/components/AssetEventsPanel/interfaces.ts
+++ b/src/components/AssetEventsPanel/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteEvent } from '@cognite/sdk';
 import React, { CSSProperties } from 'react';
 import { WithAssetEventsDataProps, WithAssetEventsProps } from '../../hoc';

--- a/src/components/AssetEventsPanel/stories/helper.tsx
+++ b/src/components/AssetEventsPanel/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteEvent } from '@cognite/sdk';
 import React, { FC } from 'react';
 import { fakeEvents, MockCogniteClient, sleep } from '../../../mocks';

--- a/src/components/AssetMeta/AssetMeta.test.tsx
+++ b/src/components/AssetMeta/AssetMeta.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/AssetMeta/AssetMeta.tsx
+++ b/src/components/AssetMeta/AssetMeta.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset, CogniteClient } from '@cognite/sdk';
 import { Tabs } from 'antd';
 import React, { Component } from 'react';

--- a/src/components/AssetMeta/index.ts
+++ b/src/components/AssetMeta/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export { AssetMeta } from './AssetMeta';
 export * from './interfaces';

--- a/src/components/AssetMeta/interfaces.ts
+++ b/src/components/AssetMeta/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CSSProperties, ReactNode } from 'react';
 import { Theme } from '../../interfaces';
 import {

--- a/src/components/AssetMeta/stories/helper.tsx
+++ b/src/components/AssetMeta/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 import {
   DOCUMENTS,

--- a/src/components/AssetScanner/AssetScanner.tsx
+++ b/src/components/AssetScanner/AssetScanner.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset, CogniteClient } from '@cognite/sdk';
 import React, { Component } from 'react';
 import styled from 'styled-components';

--- a/src/components/AssetScanner/Webcam/Webcam.tsx
+++ b/src/components/AssetScanner/Webcam/Webcam.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React, { Component } from 'react';
 import styled from 'styled-components';
 import { Callback, PureObject } from '../../../interfaces';

--- a/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.test.tsx
+++ b/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { mount } from 'enzyme';
 import React from 'react';
 import {

--- a/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
+++ b/src/components/AssetScanner/WebcamCropPlaceholder/WebcamCropPlaceholder.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 import styled from 'styled-components';
 

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.test.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { mount } from 'enzyme';
 import React from 'react';
 

--- a/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
+++ b/src/components/AssetScanner/WebcamScanner/WebcamScanner.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 import styled from 'styled-components';
 

--- a/src/components/AssetScanner/WebcamScreenshot/WebcamScreenshot.tsx
+++ b/src/components/AssetScanner/WebcamScreenshot/WebcamScreenshot.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 import styled from 'styled-components';
 

--- a/src/components/AssetScanner/index.ts
+++ b/src/components/AssetScanner/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './AssetScanner';
 export * from './interfaces';

--- a/src/components/AssetScanner/interfaces.ts
+++ b/src/components/AssetScanner/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset } from '@cognite/sdk';
 import { ComponentType, CSSProperties, ReactNode } from 'react';
 import { Callback, CropSize, EmptyCallback } from '../../interfaces';

--- a/src/components/AssetScanner/stories/helper.tsx
+++ b/src/components/AssetScanner/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { message } from 'antd';
 import React, { useState } from 'react';
 import styled from 'styled-components';

--- a/src/components/AssetSearch/AssetSearch.test.tsx
+++ b/src/components/AssetSearch/AssetSearch.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Input } from 'antd';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/AssetSearch/AssetSearch.tsx
+++ b/src/components/AssetSearch/AssetSearch.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React, { Component } from 'react';
 
 import { Asset, AssetSearchFilter } from '@cognite/sdk';

--- a/src/components/AssetSearch/index.ts
+++ b/src/components/AssetSearch/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export { AssetSearch } from './AssetSearch';
 export * from './interfaces';

--- a/src/components/AssetSearch/interfaces.ts
+++ b/src/components/AssetSearch/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset } from '@cognite/sdk';
 import { Callback, PureObject } from '../../interfaces';
 import { SearchStyles } from '../common/Search/interfaces';

--- a/src/components/AssetSearch/stories/helper.tsx
+++ b/src/components/AssetSearch/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset, AssetListScope, AssetSearchFilter } from '@cognite/sdk';
 import { pick } from 'lodash';
 import React from 'react';

--- a/src/components/AssetTimeseriesPanel/AssetTimeseriesPanel.test.tsx
+++ b/src/components/AssetTimeseriesPanel/AssetTimeseriesPanel.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/AssetTimeseriesPanel/AssetTimeseriesPanel.tsx
+++ b/src/components/AssetTimeseriesPanel/AssetTimeseriesPanel.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { withAssetTimeseries } from '../../hoc';
 import {
   TimeseriesPanelProps,

--- a/src/components/AssetTimeseriesPanel/components/TimeseriesPanelPure.test.tsx
+++ b/src/components/AssetTimeseriesPanel/components/TimeseriesPanelPure.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/AssetTimeseriesPanel/components/TimeseriesPanelPure.tsx
+++ b/src/components/AssetTimeseriesPanel/components/TimeseriesPanelPure.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Collapse } from 'antd';
 import React from 'react';
 import styled from 'styled-components';

--- a/src/components/AssetTimeseriesPanel/index.ts
+++ b/src/components/AssetTimeseriesPanel/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export { AssetTimeseriesPanel } from './AssetTimeseriesPanel';
 export * from './interfaces';

--- a/src/components/AssetTimeseriesPanel/interfaces.ts
+++ b/src/components/AssetTimeseriesPanel/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 import { WithAssetTimeseriesProps } from '../../hoc';
 import { Theme } from '../../interfaces';

--- a/src/components/AssetTimeseriesPanel/stories/helper.tsx
+++ b/src/components/AssetTimeseriesPanel/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { GetTimeSeriesMetadataDTO } from '@cognite/sdk';
 import { CogniteAsyncIterator } from '@cognite/sdk';
 import React, { FC } from 'react';

--- a/src/components/AssetTree/AssetTree.test.tsx
+++ b/src/components/AssetTree/AssetTree.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Tree } from 'antd';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/AssetTree/AssetTree.tsx
+++ b/src/components/AssetTree/AssetTree.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset, CogniteClient } from '@cognite/sdk';
 import { Spin, Tree } from 'antd';
 import { AntTreeNode, AntTreeNodeProps } from 'antd/lib/tree';

--- a/src/components/AssetTree/index.ts
+++ b/src/components/AssetTree/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './AssetTree';
 export * from './interfaces';

--- a/src/components/AssetTree/interfaces.ts
+++ b/src/components/AssetTree/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset, Limit } from '@cognite/sdk';
 import { Theme } from '../../interfaces';
 

--- a/src/components/AssetTree/stories/helper.tsx
+++ b/src/components/AssetTree/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 import {
   ASSET_LIST_CHILD,

--- a/src/components/ClientSDKProvider/ClientSDKProvider.tsx
+++ b/src/components/ClientSDKProvider/ClientSDKProvider.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React, { FC } from 'react';
 import { ClientSDKContext } from '../../context/clientSDKContext';
 import { ClientSDKProxyProvider } from './ClientSDKProxyProvider';

--- a/src/components/ClientSDKProvider/ClientSDKProxyProvider.tsx
+++ b/src/components/ClientSDKProvider/ClientSDKProxyProvider.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React, { FC } from 'react';
 import { ClientSDKProxyContext } from '../../context/clientSDKProxyContext';
 import { wrapInProxies } from '../../proxies/clientSDKProxies';

--- a/src/components/ClientSDKProvider/index.ts
+++ b/src/components/ClientSDKProvider/index.ts
@@ -1,1 +1,2 @@
+// Copyright 2020 Cognite AS
 export * from './ClientSDKProvider';

--- a/src/components/ClientSDKProvider/interfaces.ts
+++ b/src/components/ClientSDKProvider/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import React from 'react';
 

--- a/src/components/DescriptionList/DescriptionList.test.tsx
+++ b/src/components/DescriptionList/DescriptionList.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/DescriptionList/DescriptionList.tsx
+++ b/src/components/DescriptionList/DescriptionList.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Collapse } from 'antd';
 import { Dictionary, groupBy } from 'lodash';
 import React, { FC, Fragment } from 'react';

--- a/src/components/DescriptionList/index.ts
+++ b/src/components/DescriptionList/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './DescriptionList';
 export * from './interfaces';

--- a/src/components/DescriptionList/interfaces.ts
+++ b/src/components/DescriptionList/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CSSProperties } from 'react';
 import { Theme } from '../../interfaces';
 

--- a/src/components/DescriptionList/stories/helper.tsx
+++ b/src/components/DescriptionList/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React, { FC } from 'react';
 import { DescriptionListProps } from '../interfaces';
 

--- a/src/components/EventPreview/EventPreview.test.tsx
+++ b/src/components/EventPreview/EventPreview.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/EventPreview/EventPreview.tsx
+++ b/src/components/EventPreview/EventPreview.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient, CogniteEvent } from '@cognite/sdk';
 import { Spin } from 'antd';
 import React, { Component } from 'react';

--- a/src/components/EventPreview/components/EventPreviewView.test.tsx
+++ b/src/components/EventPreview/components/EventPreviewView.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteEvent } from '@cognite/sdk';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/EventPreview/components/EventPreviewView.tsx
+++ b/src/components/EventPreview/components/EventPreviewView.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteEvent } from '@cognite/sdk';
 import { Button } from 'antd';
 import React from 'react';

--- a/src/components/EventPreview/index.ts
+++ b/src/components/EventPreview/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export { EventPreview } from './EventPreview';
 export * from './interfaces';

--- a/src/components/EventPreview/interfaces.ts
+++ b/src/components/EventPreview/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteEvent } from '@cognite/sdk';
 import { CSSProperties } from 'react';
 import { PureObject } from '../../interfaces';

--- a/src/components/EventPreview/stories/helper.tsx
+++ b/src/components/EventPreview/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteEvent, IdEither } from '@cognite/sdk';
 import React from 'react';
 import { fakeEvents, MockCogniteClient, sleep } from '../../../mocks';

--- a/src/components/EventsTimeline/EventsTimeline.test.tsx
+++ b/src/components/EventsTimeline/EventsTimeline.test.tsx
@@ -1,4 +1,6 @@
 // Copyright 2020 Cognite AS
+
+// should be placed before EventTimeline import
 jest.mock('d3', () => ({
   event: {
     type: 'zoom',

--- a/src/components/EventsTimeline/EventsTimeline.test.tsx
+++ b/src/components/EventsTimeline/EventsTimeline.test.tsx
@@ -1,4 +1,4 @@
-// should be placed before EventTimeline import
+// Copyright 2020 Cognite AS
 jest.mock('d3', () => ({
   event: {
     type: 'zoom',

--- a/src/components/EventsTimeline/EventsTimeline.tsx
+++ b/src/components/EventsTimeline/EventsTimeline.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Dictionary, groupBy } from 'lodash';
 import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';

--- a/src/components/EventsTimeline/components/ChartLayout.test.tsx
+++ b/src/components/EventsTimeline/components/ChartLayout.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React, { useRef } from 'react';

--- a/src/components/EventsTimeline/components/ChartLayout.tsx
+++ b/src/components/EventsTimeline/components/ChartLayout.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { event as d3Event } from 'd3';
 import { select } from 'd3-selection';
 import {

--- a/src/components/EventsTimeline/components/Event.test.tsx
+++ b/src/components/EventsTimeline/components/Event.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/EventsTimeline/components/Event.tsx
+++ b/src/components/EventsTimeline/components/Event.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 import styled from 'styled-components';
 import { EventTimelineType, EventTimelineView } from '../interfaces';

--- a/src/components/EventsTimeline/components/Ruler.test.tsx
+++ b/src/components/EventsTimeline/components/Ruler.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/EventsTimeline/components/Ruler.tsx
+++ b/src/components/EventsTimeline/components/Ruler.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React, { useState } from 'react';
 import { EventTimelineRulerProps } from './interfaces';
 

--- a/src/components/EventsTimeline/components/Timeline.test.tsx
+++ b/src/components/EventsTimeline/components/Timeline.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/EventsTimeline/components/Timeline.tsx
+++ b/src/components/EventsTimeline/components/Timeline.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 import { Event } from './Event';
 import { TimelineProps } from './interfaces';

--- a/src/components/EventsTimeline/components/index.ts
+++ b/src/components/EventsTimeline/components/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export * from './Event';
 export * from './Ruler';
 export * from './Timeline';

--- a/src/components/EventsTimeline/components/interfaces.ts
+++ b/src/components/EventsTimeline/components/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { ScaleTime } from 'd3-scale';
 import { Dictionary } from 'lodash';
 import { RefObject, SyntheticEvent } from 'react';

--- a/src/components/EventsTimeline/helpers.ts
+++ b/src/components/EventsTimeline/helpers.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { ScaleTime, scaleTime } from 'd3-scale';
 import { Dictionary } from 'lodash';
 import { CogniteEventForTimeline } from './interfaces';

--- a/src/components/EventsTimeline/index.ts
+++ b/src/components/EventsTimeline/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './EventsTimeline';
 export * from './interfaces';

--- a/src/components/EventsTimeline/interfaces.ts
+++ b/src/components/EventsTimeline/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteEvent } from '@cognite/sdk';
 import { SyntheticEvent } from 'react';
 

--- a/src/components/EventsTimeline/mocks/events.ts
+++ b/src/components/EventsTimeline/mocks/events.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { fakeEvents } from '../../../mocks';
 import {
   CogniteEventForTimeline,

--- a/src/components/EventsTimeline/mocks/time.ts
+++ b/src/components/EventsTimeline/mocks/time.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { baseTimestamp } from '../../../mocks';
 
 export const start = baseTimestamp;

--- a/src/components/EventsTimeline/stories/EventsTimelineTooltip.tsx
+++ b/src/components/EventsTimeline/stories/EventsTimelineTooltip.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React, { useState } from 'react';
 import styled from 'styled-components';
 import { EventsTimeline } from '../EventsTimeline';

--- a/src/components/EventsTimeline/stories/helper.tsx
+++ b/src/components/EventsTimeline/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import moment from 'moment';
 import React from 'react';
 import { MockCogniteClient, sleep } from '../../../mocks';

--- a/src/components/Model3DViewer/Model3DViewer.test.tsx
+++ b/src/components/Model3DViewer/Model3DViewer.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/Model3DViewer/Model3DViewer.tsx
+++ b/src/components/Model3DViewer/Model3DViewer.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Cognite3DModel, Cognite3DViewer, THREE } from '@cognite/3d-viewer';
 import { AssetMapping3D, CogniteClient, Revision3D } from '@cognite/sdk';
 import { Button, Slider } from 'antd';

--- a/src/components/Model3DViewer/index.ts
+++ b/src/components/Model3DViewer/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export { Model3DViewer } from './Model3DViewer';
 export { Model3DViewerProps } from './interfaces';

--- a/src/components/Model3DViewer/interfaces.ts
+++ b/src/components/Model3DViewer/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { THREE } from '@cognite/3d-viewer';
 import React from 'react';
 import { CacheObject, Callback } from '../../interfaces';

--- a/src/components/Model3DViewer/stories/helper.tsx
+++ b/src/components/Model3DViewer/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { OnProgressData } from '@cognite/3d-viewer';
 import React from 'react';
 import * as THREE from 'three';

--- a/src/components/SVGViewer/Icons/Close.tsx
+++ b/src/components/SVGViewer/Icons/Close.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 
 const Close = () => (

--- a/src/components/SVGViewer/Icons/FindInPage.tsx
+++ b/src/components/SVGViewer/Icons/FindInPage.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 
 const FindInPage = () => (

--- a/src/components/SVGViewer/Icons/ZoomIn.tsx
+++ b/src/components/SVGViewer/Icons/ZoomIn.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 
 const ZoomIn = () => (

--- a/src/components/SVGViewer/Icons/ZoomOut.tsx
+++ b/src/components/SVGViewer/Icons/ZoomOut.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 
 const ZoomOut = () => (

--- a/src/components/SVGViewer/Icons/index.ts
+++ b/src/components/SVGViewer/Icons/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export { default as ZoomIn } from './ZoomIn';
 export { default as ZoomOut } from './ZoomOut';
 export { default as FindInPage } from './FindInPage';

--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import { Icon } from 'antd';
 import PinchZoom from 'pinch-zoom-js';

--- a/src/components/SVGViewer/SVGViewerSearch.tsx
+++ b/src/components/SVGViewer/SVGViewerSearch.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Icon } from 'antd';
 import React, { KeyboardEvent, MouseEvent } from 'react';
 import styled from 'styled-components';

--- a/src/components/SVGViewer/__tests__/SVGViewer.test.tsx
+++ b/src/components/SVGViewer/__tests__/SVGViewer.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/SVGViewer/__tests__/SVGViewerSearch.test.tsx
+++ b/src/components/SVGViewer/__tests__/SVGViewerSearch.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/SVGViewer/index.ts
+++ b/src/components/SVGViewer/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './SVGViewer';
 export * from './interfaces';

--- a/src/components/SVGViewer/interfaces.ts
+++ b/src/components/SVGViewer/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export interface Conditions {
   condition: (metadataNode: Element) => boolean;
   className: string;

--- a/src/components/SVGViewer/stories/helper.tsx
+++ b/src/components/SVGViewer/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { FileLink, IdEither } from '@cognite/sdk';
 import React, { FC } from 'react';
 import styled from 'styled-components';

--- a/src/components/SVGViewer/utils.ts
+++ b/src/components/SVGViewer/utils.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 
 export const getDocumentDownloadLink = async (

--- a/src/components/SensorOverlay/SensorOverlay.test.tsx
+++ b/src/components/SensorOverlay/SensorOverlay.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/SensorOverlay/SensorOverlay.tsx
+++ b/src/components/SensorOverlay/SensorOverlay.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { omit, sortedIndex } from 'lodash';
 import React, { Component } from 'react';
 import {

--- a/src/components/SensorOverlay/components/DraggableBox.test.tsx
+++ b/src/components/SensorOverlay/components/DraggableBox.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/SensorOverlay/components/DraggableBox.tsx
+++ b/src/components/SensorOverlay/components/DraggableBox.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   CogniteClient,
   DatapointsGetDatapoint,

--- a/src/components/SensorOverlay/components/DraggablePoint.test.tsx
+++ b/src/components/SensorOverlay/components/DraggablePoint.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/SensorOverlay/components/DraggablePoint.tsx
+++ b/src/components/SensorOverlay/components/DraggablePoint.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React, { Component } from 'react';
 import {
   ConnectDragPreview,

--- a/src/components/SensorOverlay/components/StyledOdometer.tsx
+++ b/src/components/SensorOverlay/components/StyledOdometer.tsx
@@ -1,8 +1,4 @@
-/**
- * This is wrapper for react-odometerjs component that replaces
- * default odometer theme. Origin - https://github.com/HubSpot/odometer/blob/master/themes/odometer-theme-default.css
- * It's needed to avoid loading odometer theme CSS from CDN.
- */
+// Copyright 2020 Cognite AS
 
 import styled from 'styled-components';
 

--- a/src/components/SensorOverlay/components/StyledOdometer.tsx
+++ b/src/components/SensorOverlay/components/StyledOdometer.tsx
@@ -1,4 +1,9 @@
 // Copyright 2020 Cognite AS
+/**
+ * This is wrapper for react-odometerjs component that replaces
+ * default odometer theme. Origin - https://github.com/HubSpot/odometer/blob/master/themes/odometer-theme-default.css
+ * It's needed to avoid loading odometer theme CSS from CDN.
+ */
 
 import styled from 'styled-components';
 

--- a/src/components/SensorOverlay/components/SvgLine.tsx
+++ b/src/components/SensorOverlay/components/SvgLine.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 
 interface SvgLineProps {

--- a/src/components/SensorOverlay/constants.ts
+++ b/src/components/SensorOverlay/constants.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export enum DragTargets {
   Box = 'infographic-box',
   Point = 'infographic-point',

--- a/src/components/SensorOverlay/index.ts
+++ b/src/components/SensorOverlay/index.ts
@@ -1,1 +1,2 @@
+// Copyright 2020 Cognite AS
 export * from './SensorOverlay';

--- a/src/components/SensorOverlay/interfaces.ts
+++ b/src/components/SensorOverlay/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { ReactNode } from 'react';
 import { ConnectDropTarget } from 'react-dnd';
 

--- a/src/components/SensorOverlay/stories/helper.tsx
+++ b/src/components/SensorOverlay/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { GetTimeSeriesMetadataDTO } from '@cognite/sdk';
 import React from 'react';
 import { sleep, timeseriesListV2 as fakeTimeseries } from '../../../mocks';

--- a/src/components/TenantSelector/TenantSelector.test.tsx
+++ b/src/components/TenantSelector/TenantSelector.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/TenantSelector/TenantSelector.tsx
+++ b/src/components/TenantSelector/TenantSelector.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Button, Collapse, Form, Input, Spin } from 'antd';
 import { NativeButtonProps } from 'antd/lib/button/button';
 import { InputProps } from 'antd/lib/input';

--- a/src/components/TenantSelector/index.ts
+++ b/src/components/TenantSelector/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export { TenantSelector } from './TenantSelector';
 
 export * from './interfaces';

--- a/src/components/TenantSelector/interfaces.ts
+++ b/src/components/TenantSelector/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { FormItemProps } from 'antd/lib/form/FormItem';
 import React, { CSSProperties } from 'react';
 import { PureObject, Theme } from '../../interfaces';

--- a/src/components/TenantSelector/stories/helper.tsx
+++ b/src/components/TenantSelector/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { PureObject } from '../../../interfaces';
 
 export const onTenantSelected = (

--- a/src/components/ThreeDNodeTree/ThreeDNodeTree.test.tsx
+++ b/src/components/ThreeDNodeTree/ThreeDNodeTree.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/ThreeDNodeTree/ThreeDNodeTree.tsx
+++ b/src/components/ThreeDNodeTree/ThreeDNodeTree.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient, List3DNodesQuery, RevealNode3D } from '@cognite/sdk';
 import { Tree } from 'antd';
 import {

--- a/src/components/ThreeDNodeTree/index.ts
+++ b/src/components/ThreeDNodeTree/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export { ThreeDNodeTree } from './ThreeDNodeTree';
 export * from './interfaces';

--- a/src/components/ThreeDNodeTree/interfaces.ts
+++ b/src/components/ThreeDNodeTree/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { RevealNode3D } from '@cognite/sdk';
 import { AntTreeNodeProps } from 'antd/lib/tree';
 import { CSSProperties, MouseEvent } from 'react';

--- a/src/components/ThreeDNodeTree/stories/helper.tsx
+++ b/src/components/ThreeDNodeTree/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { List3DNodesQuery } from '@cognite/sdk';
 import { Menu } from 'antd';
 import MenuItem from 'antd/lib/menu/MenuItem';

--- a/src/components/TimeseriesChart/TimeseriesChart.test.tsx
+++ b/src/components/TimeseriesChart/TimeseriesChart.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import lodash from 'lodash';

--- a/src/components/TimeseriesChart/TimeseriesChart.tsx
+++ b/src/components/TimeseriesChart/TimeseriesChart.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import React, { Component } from 'react';
 import styled from 'styled-components';

--- a/src/components/TimeseriesChart/components/CursorOverview.tsx
+++ b/src/components/TimeseriesChart/components/CursorOverview.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import moment from 'moment';
 import numeral from 'numeral';
 import React from 'react';

--- a/src/components/TimeseriesChart/dataLoader.test.tsx
+++ b/src/components/TimeseriesChart/dataLoader.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   GetAggregateDatapoint,
   GetDoubleDatapoint,

--- a/src/components/TimeseriesChart/dataLoader.ts
+++ b/src/components/TimeseriesChart/dataLoader.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { DataProviderLoaderParams, Series } from '@cognite/griff-react';
 import { CogniteClient } from '@cognite/sdk';
 import {

--- a/src/components/TimeseriesChart/index.ts
+++ b/src/components/TimeseriesChart/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './TimeseriesChart';
 export * from './interfaces';

--- a/src/components/TimeseriesChart/interfaces.ts
+++ b/src/components/TimeseriesChart/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   Annotation,
   DataProviderSeries as ProviderSeries,

--- a/src/components/TimeseriesChart/stories/helper.tsx
+++ b/src/components/TimeseriesChart/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { AxisDisplayMode } from '@cognite/griff-react';
 import {
   DatapointsGetAggregateDatapoint,

--- a/src/components/TimeseriesChartMeta/TimeseriesChartMeta.tsx
+++ b/src/components/TimeseriesChartMeta/TimeseriesChartMeta.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { withTimeseries } from '../../hoc';
 import { TimeseriesChartMetaPure } from './TimeseriesChartMetaPure';
 

--- a/src/components/TimeseriesChartMeta/TimeseriesChartMetaPure.test.tsx
+++ b/src/components/TimeseriesChartMeta/TimeseriesChartMetaPure.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/TimeseriesChartMeta/TimeseriesChartMetaPure.tsx
+++ b/src/components/TimeseriesChartMeta/TimeseriesChartMetaPure.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Radio } from 'antd';
 import { RadioChangeEvent } from 'antd/lib/radio';
 import moment from 'moment';

--- a/src/components/TimeseriesChartMeta/components/TimeseriesMetaInfo.test.tsx
+++ b/src/components/TimeseriesChartMeta/components/TimeseriesMetaInfo.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/TimeseriesChartMeta/components/TimeseriesMetaInfo.tsx
+++ b/src/components/TimeseriesChartMeta/components/TimeseriesMetaInfo.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Collapse } from 'antd';
 import React, { FC } from 'react';
 import styled from 'styled-components';

--- a/src/components/TimeseriesChartMeta/components/TimeseriesValue.test.tsx
+++ b/src/components/TimeseriesChartMeta/components/TimeseriesValue.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/TimeseriesChartMeta/components/TimeseriesValue.tsx
+++ b/src/components/TimeseriesChartMeta/components/TimeseriesValue.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import React from 'react';
 import styled from 'styled-components';

--- a/src/components/TimeseriesChartMeta/index.ts
+++ b/src/components/TimeseriesChartMeta/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './TimeseriesChartMeta';
 export * from './interfaces';

--- a/src/components/TimeseriesChartMeta/interfaces.ts
+++ b/src/components/TimeseriesChartMeta/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { WithTimeseriesProps } from '../../hoc';
 import { timeScales } from './TimeseriesChartMetaPure';
 

--- a/src/components/TimeseriesChartMeta/stories/helper.tsx
+++ b/src/components/TimeseriesChartMeta/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { GetTimeSeriesMetadataDTO } from '@cognite/sdk';
 import React, { FC } from 'react';
 import {

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   DatapointsMultiQuery,
   GetTimeSeriesMetadataDTO,

--- a/src/components/TimeseriesDataExport/constants.ts
+++ b/src/components/TimeseriesDataExport/constants.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export const defaultStrings = {
   title: 'Export chart data',
   labelRange: 'Range',

--- a/src/components/TimeseriesDataExport/index.ts
+++ b/src/components/TimeseriesDataExport/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export { TimeseriesDataExport } from './TimeseriesDataExport';
 export * from './interfaces';

--- a/src/components/TimeseriesDataExport/interfaces.ts
+++ b/src/components/TimeseriesDataExport/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   Aggregate,
   DatapointsMultiQuery,

--- a/src/components/TimeseriesDataExport/stories/helper.tsx
+++ b/src/components/TimeseriesDataExport/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   DatapointsGetAggregateDatapoint,
   DatapointsMultiQuery,

--- a/src/components/TimeseriesPreview/TimeseriesPreview.test.tsx
+++ b/src/components/TimeseriesPreview/TimeseriesPreview.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Dropdown } from 'antd';
 import { configure, mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/TimeseriesPreview/TimeseriesPreview.tsx
+++ b/src/components/TimeseriesPreview/TimeseriesPreview.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   GetDoubleDatapoint,
   GetStringDatapoint,

--- a/src/components/TimeseriesPreview/index.ts
+++ b/src/components/TimeseriesPreview/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './interfaces';
 export { TimeseriesPreview } from './TimeseriesPreview';

--- a/src/components/TimeseriesPreview/interfaces.ts
+++ b/src/components/TimeseriesPreview/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   DatapointsGetDatapoint,
   GetDoubleDatapoint,

--- a/src/components/TimeseriesPreview/stories/helper.tsx
+++ b/src/components/TimeseriesPreview/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { GetTimeSeriesMetadataDTO, InternalId } from '@cognite/sdk';
 import React from 'react';
 import { randomLatestDatapoint, singleTimeseries, sleep } from '../../../mocks';

--- a/src/components/TimeseriesSearch/SelectedItems.tsx
+++ b/src/components/TimeseriesSearch/SelectedItems.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Tag } from 'antd';
 import React from 'react';
 import styled from 'styled-components';

--- a/src/components/TimeseriesSearch/TimeseriesSearch.test.tsx
+++ b/src/components/TimeseriesSearch/TimeseriesSearch.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Button, Input, Tag } from 'antd';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/TimeseriesSearch/TimeseriesSearch.tsx
+++ b/src/components/TimeseriesSearch/TimeseriesSearch.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { GetTimeSeriesMetadataDTO } from '@cognite/sdk';
 import { CogniteClient } from '@cognite/sdk';
 import { Button, Spin } from 'antd';

--- a/src/components/TimeseriesSearch/index.ts
+++ b/src/components/TimeseriesSearch/index.ts
@@ -1,2 +1,3 @@
+// Copyright 2020 Cognite AS
 export * from './TimeseriesSearch';
 export * from './interfaces';

--- a/src/components/TimeseriesSearch/interfaces.ts
+++ b/src/components/TimeseriesSearch/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { GetTimeSeriesMetadataDTO } from '@cognite/sdk';
 import React from 'react';
 import { PureObject } from '../../interfaces';

--- a/src/components/TimeseriesSearch/stories/helper.tsx
+++ b/src/components/TimeseriesSearch/stories/helper.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   GetTimeSeriesMetadataDTO,
   TimeseriesIdEither,

--- a/src/components/common/ComplexString/ComplexString.tsx
+++ b/src/components/common/ComplexString/ComplexString.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 import { ID } from '../../../interfaces';
 

--- a/src/components/common/DetailCheckbox/DetailCheckbox.tsx
+++ b/src/components/common/DetailCheckbox/DetailCheckbox.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Checkbox } from 'antd';
 import React, { FC } from 'react';
 import styled from 'styled-components';

--- a/src/components/common/LoadingBlock/LoadingBlock.tsx
+++ b/src/components/common/LoadingBlock/LoadingBlock.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React, { FC } from 'react';
 import styled from 'styled-components';
 import { LoadingOverlay } from '../LoadingOverlay/LoadingOverlay';

--- a/src/components/common/LoadingOverlay/LoadingOverlay.tsx
+++ b/src/components/common/LoadingOverlay/LoadingOverlay.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Spin } from 'antd';
 import React from 'react';
 import styled from 'styled-components';

--- a/src/components/common/RootAssetSelect/RootAssetSelect.test.tsx
+++ b/src/components/common/RootAssetSelect/RootAssetSelect.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Select } from 'antd';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/common/RootAssetSelect/RootAssetSelect.tsx
+++ b/src/components/common/RootAssetSelect/RootAssetSelect.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset, CogniteClient } from '@cognite/sdk';
 import { Select } from 'antd';
 import React from 'react';

--- a/src/components/common/Search/Search.test.tsx
+++ b/src/components/common/Search/Search.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Input } from 'antd';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/common/Search/Search.tsx
+++ b/src/components/common/Search/Search.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Button, Icon, Input, Modal } from 'antd';
 import { NativeButtonProps } from 'antd/lib/button/button';
 import { debounce } from 'lodash';

--- a/src/components/common/Search/SearchForm/SearchForm.test.tsx
+++ b/src/components/common/Search/SearchForm/SearchForm.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Input } from 'antd';
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/components/common/Search/SearchForm/SearchForm.tsx
+++ b/src/components/common/Search/SearchForm/SearchForm.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Button, Form, Icon, Input } from 'antd';
 import { WrappedFormUtils } from 'antd/lib/form/Form';
 import React, { SyntheticEvent } from 'react';

--- a/src/components/common/Search/interfaces.ts
+++ b/src/components/common/Search/interfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CSSProperties } from 'react';
 
 export interface SearchStyles {

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export const ERROR_NO_SDK_CLIENT =
   'Client SDK Context has not been provided. Use ClientSDKProvider to wrap the component.';
 export const ERROR_API_UNEXPECTED_RESULTS =

--- a/src/constants/replacedStrings.ts
+++ b/src/constants/replacedStrings.ts
@@ -1,1 +1,2 @@
+// Copyright 2020 Cognite AS
 export const version = '__REPLACE_package_version__';

--- a/src/constants/sdk.ts
+++ b/src/constants/sdk.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export const SDK_LIST_LIMIT = 1000;
 export const SDK_EXCLUDE_FROM_TRACKING_METHODS = [
   'setOneTimeSdkHeader',

--- a/src/context/clientSDKCacheContext.ts
+++ b/src/context/clientSDKCacheContext.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   AssetList,
   CogniteClient,

--- a/src/context/clientSDKContext.ts
+++ b/src/context/clientSDKContext.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import React from 'react';
 

--- a/src/context/clientSDKProxyContext.test.tsx
+++ b/src/context/clientSDKProxyContext.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount, ReactWrapper } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/context/clientSDKProxyContext.ts
+++ b/src/context/clientSDKProxyContext.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React, { useContext } from 'react';
 import { ClientSDKContextType } from './clientSDKContext';
 

--- a/src/hoc/index.ts
+++ b/src/hoc/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export * from './interfaces';
 export * from './withAsset';
 export * from './withAssetEvents';

--- a/src/hoc/interfaces/WithAssetEventsInterfaces.ts
+++ b/src/hoc/interfaces/WithAssetEventsInterfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteEvent, EventFilterRequest } from '@cognite/sdk';
 import { ReactNode } from 'react';
 

--- a/src/hoc/interfaces/WithAssetFilesInterfaces.ts
+++ b/src/hoc/interfaces/WithAssetFilesInterfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { FileRequestFilter, FilesMetadata } from '@cognite/sdk';
 import { ReactNode } from 'react';
 

--- a/src/hoc/interfaces/WithAssetInterfaces.ts
+++ b/src/hoc/interfaces/WithAssetInterfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset } from '@cognite/sdk';
 import { ReactNode } from 'react';
 

--- a/src/hoc/interfaces/WithAssetTimeseriesInterfaces.ts
+++ b/src/hoc/interfaces/WithAssetTimeseriesInterfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { GetTimeSeriesMetadataDTO, TimeseriesFilter } from '@cognite/sdk';
 import { ReactNode } from 'react';
 

--- a/src/hoc/interfaces/WithDefaultThemeInterfaces.ts
+++ b/src/hoc/interfaces/WithDefaultThemeInterfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { defaultTheme } from '../../theme/defaultTheme';
 
 type GearboxThemeKey = keyof typeof defaultTheme;

--- a/src/hoc/interfaces/WithTimeseriesInterfaces.ts
+++ b/src/hoc/interfaces/WithTimeseriesInterfaces.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { GetTimeSeriesMetadataDTO } from '@cognite/sdk';
 import { ReactNode } from 'react';
 

--- a/src/hoc/interfaces/index.ts
+++ b/src/hoc/interfaces/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export * from './WithAssetInterfaces';
 export * from './WithAssetEventsInterfaces';
 export * from './WithAssetFilesInterfaces';

--- a/src/hoc/tests/withAsset.test.tsx
+++ b/src/hoc/tests/withAsset.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React, { FC } from 'react';

--- a/src/hoc/tests/withAssetEvents.test.tsx
+++ b/src/hoc/tests/withAssetEvents.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React, { FC } from 'react';

--- a/src/hoc/tests/withAssetFiles.test.tsx
+++ b/src/hoc/tests/withAssetFiles.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React, { FC } from 'react';

--- a/src/hoc/tests/withAssetTimeseries.test.tsx
+++ b/src/hoc/tests/withAssetTimeseries.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React, { FC } from 'react';

--- a/src/hoc/tests/withDefaultTheme.test.tsx
+++ b/src/hoc/tests/withDefaultTheme.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React from 'react';

--- a/src/hoc/tests/withTimeseries.test.tsx
+++ b/src/hoc/tests/withTimeseries.test.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import React, { FC } from 'react';

--- a/src/hoc/withAsset.tsx
+++ b/src/hoc/withAsset.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import React from 'react';
 import { LoadingBlock } from '../components/common/LoadingBlock/LoadingBlock';

--- a/src/hoc/withAssetEvents.tsx
+++ b/src/hoc/withAssetEvents.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import React from 'react';
 import { LoadingBlock } from '../components/common/LoadingBlock/LoadingBlock';

--- a/src/hoc/withAssetFiles.tsx
+++ b/src/hoc/withAssetFiles.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import React from 'react';
 import { LoadingBlock } from '../components/common/LoadingBlock/LoadingBlock';

--- a/src/hoc/withAssetTimeseries.tsx
+++ b/src/hoc/withAssetTimeseries.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient, GetTimeSeriesMetadataDTO } from '@cognite/sdk';
 import React from 'react';
 import { LoadingBlock } from '../components/common/LoadingBlock/LoadingBlock';

--- a/src/hoc/withDefaultTheme.tsx
+++ b/src/hoc/withDefaultTheme.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import React from 'react';
 import { ThemeProvider, withTheme } from 'styled-components';
 import { Theme } from '../interfaces';

--- a/src/hoc/withTimeseries.tsx
+++ b/src/hoc/withTimeseries.tsx
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import React from 'react';
 import { LoadingBlock } from '../components/common/LoadingBlock/LoadingBlock';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export * from './components/AssetBreadcrumb';
 export * from './components/AssetMeta';
 export * from './components/AssetScanner';

--- a/src/interfaces/CommonTypes.ts
+++ b/src/interfaces/CommonTypes.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export type ID = number | string;
 export type OnAdvancedSearchChange = (searchFields: AdvancedSearch) => void;
 export type Callback = (...args: any[]) => void;

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,1 +1,2 @@
+// Copyright 2020 Cognite AS
 export * from './CommonTypes';

--- a/src/mocks/assets.ts
+++ b/src/mocks/assets.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset } from '@cognite/sdk';
 
 export const ASSET_DATA = {

--- a/src/mocks/assetsList.ts
+++ b/src/mocks/assetsList.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset } from '@cognite/sdk';
 import { AdvancedSearch } from '../interfaces';
 

--- a/src/mocks/assetsListV2.ts
+++ b/src/mocks/assetsListV2.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset } from '@cognite/sdk';
 import { AssetTreeStyles } from '../components/AssetTree';
 import {

--- a/src/mocks/common.ts
+++ b/src/mocks/common.ts
@@ -1,4 +1,11 @@
 // Copyright 2020 Cognite AS
+/**
+ * Mock wait for Promise resolve after @param timeout
+ *
+ * @param ms milliseconds timeout
+ *
+ * @return resolved Promise
+ */
 
 export const sleep = (ms: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, ms));

--- a/src/mocks/common.ts
+++ b/src/mocks/common.ts
@@ -1,10 +1,4 @@
-/**
- * Mock wait for Promise resolve after @param timeout
- *
- * @param ms milliseconds timeout
- *
- * @return resolved Promise
- */
+// Copyright 2020 Cognite AS
 
 export const sleep = (ms: number): Promise<void> =>
   new Promise(resolve => setTimeout(resolve, ms));

--- a/src/mocks/datapoints.ts
+++ b/src/mocks/datapoints.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   DatapointsGetAggregateDatapoint,
   DatapointsGetDoubleDatapoint,

--- a/src/mocks/documents.ts
+++ b/src/mocks/documents.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { FilesMetadata } from '@cognite/sdk';
 
 function generateDocumentBase(id: number): FilesMetadata {

--- a/src/mocks/events.ts
+++ b/src/mocks/events.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteEvent } from '@cognite/sdk';
 import moment from 'moment';
 import { AssetDocumentsPanelStyles } from '../components/AssetDocumentsPanel';

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export * from './assets';
 export * from './assetsList';
 export * from './assetsListV2';

--- a/src/mocks/mockSdk.ts
+++ b/src/mocks/mockSdk.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 
 export class MockCogniteClient extends CogniteClient {

--- a/src/mocks/mocks.test.ts
+++ b/src/mocks/mocks.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   eventTimelineDataObject,
   eventTimelineDataSrc,

--- a/src/mocks/svg-viewer.ts
+++ b/src/mocks/svg-viewer.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export const SVG = `<svg xmlns="http://www.w3.org/2000/svg" 
   xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 1153 776" width="1153" height="776" onload="alert('oh no, I am a security bug!')">
   <g id="Canvas" transform="scale(4) translate(-600 -200)">

--- a/src/mocks/tests/common.test.ts
+++ b/src/mocks/tests/common.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { generateNumber, sleep } from '../common';

--- a/src/mocks/threeD.ts
+++ b/src/mocks/threeD.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Cognite3DViewer, OnProgressData, THREE } from '@cognite/3d-viewer';
 import { CogniteClient } from '@cognite/sdk';
 import { Revision3D } from '@cognite/sdk';

--- a/src/mocks/threeDNodesList.ts
+++ b/src/mocks/threeDNodesList.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { RevealNode3D } from '@cognite/sdk';
 
 const container = 'container_20_feet_01';

--- a/src/mocks/timeseriesDataPointsList.ts
+++ b/src/mocks/timeseriesDataPointsList.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   DatapointsGetAggregateDatapoint,
   DatapointsGetDoubleDatapoint,

--- a/src/mocks/timeseriesListV2.ts
+++ b/src/mocks/timeseriesListV2.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { GetTimeSeriesMetadataDTO } from '@cognite/sdk';
 
 const IAA_21PT1019: GetTimeSeriesMetadataDTO[] = [

--- a/src/proxies/clientSDKCacheProxy.test.ts
+++ b/src/proxies/clientSDKCacheProxy.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { IdEither } from '@cognite/sdk';
 import { ClientSDKCache } from '../cache/ClientSDKCache';
 import { MockCogniteClient } from '../mocks';

--- a/src/proxies/clientSDKCacheProxy.ts
+++ b/src/proxies/clientSDKCacheProxy.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import { ClientSDKCache } from '../cache/ClientSDKCache';
 import { ClientApiKeys, ClientApiTypes } from './types';

--- a/src/proxies/clientSDKLogProxy.test.ts
+++ b/src/proxies/clientSDKLogProxy.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { version } from '../constants/replacedStrings';
 import { MockCogniteClient } from '../mocks';
 import { wrapInLogProxy } from './clientSDKLogProxy';

--- a/src/proxies/clientSDKLogProxy.ts
+++ b/src/proxies/clientSDKLogProxy.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import { version } from '../constants/replacedStrings';
 import { SDK_EXCLUDE_FROM_TRACKING_METHODS } from '../constants/sdk';

--- a/src/proxies/clientSDKProxies.test.ts
+++ b/src/proxies/clientSDKProxies.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { IdEither } from '@cognite/sdk';
 import { MockCogniteClient } from '../mocks';
 import { wrapInProxies } from './clientSDKProxies';

--- a/src/proxies/clientSDKProxies.ts
+++ b/src/proxies/clientSDKProxies.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { ClientSDKCache } from '../cache/ClientSDKCache';
 import { ClientSDKContextType } from '../context/clientSDKContext';
 import { ClientSDKProxyContextType } from '../context/clientSDKProxyContext';

--- a/src/proxies/types.ts
+++ b/src/proxies/types.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import { SDK_EXCLUDE_FROM_TRACKING_METHODS } from '../constants/sdk';
 

--- a/src/theme/defaultTheme.ts
+++ b/src/theme/defaultTheme.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export const defaultTheme = {
   // ant design colors
   primaryColor: '#1890ff',

--- a/src/utils/axisSigFix.ts
+++ b/src/utils/axisSigFix.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 const countDecimals = (num: number) => {
   if (!Number.isNaN(num) && Math.floor(num) !== num) {
     return num.toString().split('.')[1].length || 0;

--- a/src/utils/colors.ts
+++ b/src/utils/colors.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export const ColorList = [
   '#0097e6',
   '#e1b12c',

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   Aggregate,
   DatapointsGetAggregateDatapoint,

--- a/src/utils/documents.ts
+++ b/src/utils/documents.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   Document,
   DocumentsByCategory,

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import moment from 'moment';
 import { PureObject } from '../interfaces';
 

--- a/src/utils/notifications.ts
+++ b/src/utils/notifications.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { notification as antdNotification } from 'antd';
 
 export enum NotificationTypes {

--- a/src/utils/promise.ts
+++ b/src/utils/promise.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export interface ComponentWithUnmountState {
   isComponentUnmounted: boolean;
 }

--- a/src/utils/resources/docTypes.ts
+++ b/src/utils/resources/docTypes.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 export const docTypes = {
   AA: 'Accounting',
   AB: 'Administration (Project management)',

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,10 +1,4 @@
-/**
- * Convert input into a safe CDP project name format ([a-z0-9\-]+)
- *
- * @param input possible CDP project name
- *
- * @return the sanitized CDP project name
- */
+// Copyright 2020 Cognite AS
 export const sanitizeTenant = (input: string): string =>
   input
     // CDP projects cannot have upper-case characters

--- a/src/utils/sanitize.ts
+++ b/src/utils/sanitize.ts
@@ -1,4 +1,11 @@
 // Copyright 2020 Cognite AS
+/**
+ * Convert input into a safe CDP project name format ([a-z0-9\-]+)
+ *
+ * @param input possible CDP project name
+ *
+ * @return the sanitized CDP project name
+ */
 export const sanitizeTenant = (input: string): string =>
   input
     // CDP projects cannot have upper-case characters

--- a/src/utils/tests/axisSigFix.test.ts
+++ b/src/utils/tests/axisSigFix.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { decimalTickFormatter } from '../axisSigFix';

--- a/src/utils/tests/colors.test.ts
+++ b/src/utils/tests/colors.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { getColorByString, getColorFromPercentage } from '../colors';

--- a/src/utils/tests/csv.test.ts
+++ b/src/utils/tests/csv.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { GetTimeSeriesMetadataDTO } from '@cognite/sdk';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/utils/tests/promise.test.ts
+++ b/src/utils/tests/promise.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   CanceledPromiseException,
   ComponentWithUnmountState,

--- a/src/utils/tests/sanitize.test.ts
+++ b/src/utils/tests/sanitize.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import { sanitizeTenant } from '../sanitize';

--- a/src/utils/tests/threeD.test.ts
+++ b/src/utils/tests/threeD.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { THREE } from '@cognite/3d-viewer';
 import { Callback } from '../../interfaces';
 

--- a/src/utils/tests/utils.test.ts
+++ b/src/utils/tests/utils.test.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset } from '@cognite/sdk';
 import { configure } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { GearboxTheme } from '../hoc';
 
 export const applyThemeFontFamily = (gearboxTheme: GearboxTheme) =>

--- a/src/utils/threeD.ts
+++ b/src/utils/threeD.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import {
   Cognite3DModel,
   Cognite3DViewer,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,4 @@
+// Copyright 2020 Cognite AS
 import { Asset } from '@cognite/sdk';
 import ms from 'ms';
 import { CropSize } from '..';

--- a/yarn.lock
+++ b/yarn.lock
@@ -7528,6 +7528,11 @@ eslint-config-prettier@^6.11.0:
   dependencies:
     get-stdin "^6.0.0"
 
+eslint-plugin-header@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-header/-/eslint-plugin-header-3.0.0.tgz#0e048b5f0adfdd9754142d59d551ae6bfdaf90ad"
+  integrity sha512-OIu2ciVW8jK4Ove4JHm1I7X0C98PZuLCyCsoUhAm2HpyGS+zr34qLM6iV06unnDvssvvEh5BkOfaLRF+N7cGoQ==
+
 eslint-plugin-prettier@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz#ae116a0fc0e598fdae48743a4430903de5b4e6ca"


### PR DESCRIPTION
Adds `// Copyright 2020 Cognite` to all source files like the license says, and also adds a plugin to eslint to enforce future copyright headers