### PR TITLE
fix: round API limit param to integer

### DIFF
--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
@@ -114,13 +114,13 @@ describe('TimeseriesDataExport', () => {
 
   it('should set proper limit value', async () => {
     const apiDatapointsLimit = 10000;
-    const seriesNumber = 4; // 2 timeseries ids and 2 external ids
+    const seriesNumber = 3; // 2 timeseries ids and 1 external ids
     const granularity = 2 * 1000; // 2s in milliseconds
     await act(async () => {
       wrapper = mountComponent({
         ...defaultProps,
         timeseriesIds: [0, 1],
-        timeseriesExternalIds: ['externalId-1', 'externalId-2'],
+        timeseriesExternalIds: ['externalId-1'],
         granularity: '2s',
       } as TimeseriesDataExportProps);
     });
@@ -138,10 +138,10 @@ describe('TimeseriesDataExport', () => {
       limit,
     } = sdk.datapoints.retrieve.mock.calls[1][0];
 
-    expect(limit).toEqual(apiDatapointsLimit / seriesNumber);
-    expect(chunkEnd - chunkStart + 1).toEqual(
-      (apiDatapointsLimit * granularity) / seriesNumber
-    );
+    const expectedLimit = Math.floor(apiDatapointsLimit / seriesNumber);
+
+    expect(limit).toEqual(expectedLimit);
+    expect(chunkEnd - chunkStart + 1).toEqual(expectedLimit * granularity);
   });
 
   it('should trigger onSuccess callback if provided', async () => {

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
@@ -103,12 +103,44 @@ describe('TimeseriesDataExport', () => {
       form.simulate('submit');
     });
 
-    expect(sdk.datapoints.retrieve).toHaveBeenCalledTimes(3);
+    expect(sdk.datapoints.retrieve).toHaveBeenCalledTimes(4);
     expect(sdk.datapoints.retrieve.mock.calls[1][0].start).toEqual(
       dpStartTimestamp
     );
-    expect(sdk.datapoints.retrieve.mock.calls[2][0].end).toEqual(
+    expect(sdk.datapoints.retrieve.mock.calls[3][0].end).toEqual(
       dpEndTimestamp
+    );
+  });
+
+  it('should set proper limit value', async () => {
+    const apiDatapointsLimit = 10000;
+    const seriesNumber = 4; // 2 timeseries ids and 2 external ids
+    const granularity = 2 * 1000; // 2s in milliseconds
+    await act(async () => {
+      wrapper = mountComponent({
+        ...defaultProps,
+        timeseriesIds: [0, 1],
+        timeseriesExternalIds: ['externalId-1', 'externalId-2'],
+        granularity: '2s',
+      } as TimeseriesDataExportProps);
+    });
+
+    wrapper.update();
+    const form = wrapper.find(formIdentificator);
+
+    await act(async () => {
+      form.simulate('submit');
+    });
+
+    const {
+      start: chunkStart,
+      end: chunkEnd,
+      limit,
+    } = sdk.datapoints.retrieve.mock.calls[1][0];
+
+    expect(limit).toEqual(apiDatapointsLimit / seriesNumber);
+    expect(chunkEnd - chunkStart + 1).toEqual(
+      (apiDatapointsLimit * granularity) / seriesNumber
     );
   });
 

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -8,7 +8,7 @@ import {
 } from '@cognite/sdk';
 import { Button, Checkbox, DatePicker, Form, Input, Modal, Radio } from 'antd';
 import { FormComponentProps } from 'antd/lib/form';
-import { chunk, isFunction, range } from 'lodash';
+import { isFunction, range, last } from 'lodash';
 import moment from 'moment';
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useCogniteContext } from '../../context/clientSDKProxyContext';
@@ -132,15 +132,17 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
     request: DatapointsMultiQuery
   ): Promise<DatapointAggregates[]> => {
     const { start = 0, end = 0 } = await getLimits(request);
-    const numericGranularity = getGranularityInMS(granularity);
-    const msPerRequest =
-      (numericGranularity * CELL_LIMIT) / timeseriesIds.length;
+    const numericGranularity = getGranularityInMS(request.granularity!);
+    const limit = Math.floor(CELL_LIMIT / seriesNumber);
+    const msPerRequest = limit * numericGranularity;
 
     const ranges = range(start, end, msPerRequest);
-    const endRange =
-      ranges.length % 2 === 0 ? [end - msPerRequest, end] : [end];
-    const chunks = chunk([...ranges, ...endRange], 2);
-    const limit = Math.round(CELL_LIMIT / timeseriesIds.length);
+    const chunks = ranges.map(range => [range, range + msPerRequest - 1]);
+    const lastChunk = last(chunks);
+
+    if (lastChunk![1] > end) {
+      lastChunk![1] = end;
+    }
 
     const requests = chunks
       .map(([chunkStart, chunkEnd]) => ({

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -140,7 +140,7 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
     const endRange =
       ranges.length % 2 === 0 ? [end - msPerRequest, end] : [end];
     const chunks = chunk([...ranges, ...endRange], 2);
-    const limit = CELL_LIMIT / timeseriesIds.length;
+    const limit = Math.round(CELL_LIMIT / timeseriesIds.length);
 
     const requests = chunks
       .map(([chunkStart, chunkEnd]) => ({

--- a/src/components/TimeseriesDataExport/stories/basic.story.mdx
+++ b/src/components/TimeseriesDataExport/stories/basic.story.mdx
@@ -53,9 +53,9 @@ const TimeseriesChartExportWrapper: React.FC<
 <Preview>
   <Story name="Basic usage with timeseriesIds">
     <TimeseriesChartExportWrapper
-      timeseriesIds={[41852231325889, 7433885982156917]}
+      timeseriesIds={[5597549712998494, 403384152812777, 5893392619516417]}
       granularity={'2m'}
-      defaultTimeRange={[1567321800000, 1567408200000]}
+      defaultTimeRange={[1572423000000, 1572509400000]}
     />
   </Story>
 </Preview>
@@ -63,9 +63,9 @@ const TimeseriesChartExportWrapper: React.FC<
 <Preview>
   <Story name="Basic usage with timeseriesExternalIds">
     <TimeseriesChartExportWrapper
-      timeseriesExternalIds={['TAM_TGM_GAS_LIFT_A_ FY_31204_STR1_CALIB_TT']}
+      timeseriesExternalIds={['houston.ro.REMOTE_AI[34]', 'houston.ro.REMOTE_AI[23]', 'houston.ro.REMOTE_AI[32]']}
       granularity={'2m'}
-      defaultTimeRange={[1567321800000, 1567408200000]}
+      defaultTimeRange={[1572423000000, 1572509400000]}
     />
   </Story>
 </Preview>


### PR DESCRIPTION
API calls with floats as ´limit´ parameters are invalid and result in
400 response. This fixes potential fractions by rounding to closest
integer with the ´Math.round()´ function. 

Someone with a more in depth knowledge of the API should probably consider whether using ´Math.ceil()´ is more apropriate as that guarantees no missing datapoints (here `Math.round(10000/3) * 3` will result in `9999` datapoints) but that probably requires handling of duplicate datapoints. 