### PR TITLE
fix(timeseries-data-export): requests chunking and limit calculations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.20.1 (2020-08-26)
+
+
+### Bug Fixes
+
+* **timeseries-data-export:** requests chunking and limit calculations ([#675](https://github.com/cognitedata/gearbox.js/issues/675))
+
 # [1.20.0](https://github.com/cognitedata/gearbox.js/compare/v1.19.4...v1.20.0) (2020-07-29)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/gearbox",
-  "version": "1.20.0",
+  "version": "1.20.1",
   "description": "GearBox will be a place for application developers to contribute useful, reusable components across applications",
   "contributors": [],
   "main": "dist/index.js",

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
@@ -102,13 +102,45 @@ describe('TimeseriesDataExport', () => {
       form.simulate('submit');
     });
 
-    expect(sdk.datapoints.retrieve).toHaveBeenCalledTimes(3);
+    expect(sdk.datapoints.retrieve).toHaveBeenCalledTimes(4);
     expect(sdk.datapoints.retrieve.mock.calls[1][0].start).toEqual(
       dpStartTimestamp
     );
-    expect(sdk.datapoints.retrieve.mock.calls[2][0].end).toEqual(
+    expect(sdk.datapoints.retrieve.mock.calls[3][0].end).toEqual(
       dpEndTimestamp
     );
+  });
+
+  it('should set proper limit value', async () => {
+    const apiDatapointsLimit = 10000;
+    const seriesNumber = 3; // 2 timeseries ids and 1 external ids
+    const granularity = 2 * 1000; // 2s in milliseconds
+    await act(async () => {
+      wrapper = mountComponent({
+        ...defaultProps,
+        timeseriesIds: [0, 1],
+        timeseriesExternalIds: ['externalId-1'],
+        granularity: '2s',
+      } as TimeseriesDataExportProps);
+    });
+
+    wrapper.update();
+    const form = wrapper.find(formIdentificator);
+
+    await act(async () => {
+      form.simulate('submit');
+    });
+
+    const {
+      start: chunkStart,
+      end: chunkEnd,
+      limit,
+    } = sdk.datapoints.retrieve.mock.calls[1][0];
+
+    const expectedLimit = Math.floor(apiDatapointsLimit / seriesNumber);
+
+    expect(limit).toEqual(expectedLimit);
+    expect(chunkEnd - chunkStart + 1).toEqual(expectedLimit * granularity);
   });
 
   it('should trigger onSuccess callback if provided', async () => {

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -135,13 +135,13 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
     const { start = 0, end = 0 } = await getLimits(request);
     const numericGranularity = getGranularityInMS(granularity);
     const msPerRequest =
-      (numericGranularity * CELL_LIMIT) / timeseriesIds.length;
+      (numericGranularity * CELL_LIMIT) / seriesNumber;
 
     const ranges = range(start, end, msPerRequest);
     const endRange =
       ranges.length % 2 === 0 ? [end - msPerRequest, end] : [end];
     const chunks = chunk([...ranges, ...endRange], 2);
-    const limit = CELL_LIMIT / timeseriesIds.length;
+    const limit = CELL_LIMIT / seriesNumber;
 
     const requests = chunks
       .map(([chunkStart, chunkEnd]) => ({

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -9,7 +9,7 @@ import {
 } from '@cognite/sdk';
 import { Button, Checkbox, DatePicker, Form, Input, Modal, Radio } from 'antd';
 import { FormComponentProps } from 'antd/lib/form';
-import { chunk, isFunction, range } from 'lodash';
+import { last, isFunction, range } from 'lodash';
 import moment from 'moment';
 import React, { FC, useEffect, useMemo, useState } from 'react';
 import { useCogniteContext } from '../../context/clientSDKProxyContext';
@@ -133,15 +133,17 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
     request: DatapointsMultiQuery
   ): Promise<DatapointsGetAggregateDatapoint[]> => {
     const { start = 0, end = 0 } = await getLimits(request);
-    const numericGranularity = getGranularityInMS(granularity);
-    const msPerRequest =
-      (numericGranularity * CELL_LIMIT) / seriesNumber;
+    const numericGranularity = getGranularityInMS(request.granularity!);
+    const limit = Math.floor(CELL_LIMIT / seriesNumber);
+    const msPerRequest = limit * numericGranularity;
 
     const ranges = range(start, end, msPerRequest);
-    const endRange =
-      ranges.length % 2 === 0 ? [end - msPerRequest, end] : [end];
-    const chunks = chunk([...ranges, ...endRange], 2);
-    const limit = CELL_LIMIT / seriesNumber;
+    const chunks = ranges.map(range => [range, range + msPerRequest - 1]);
+    const lastChunk = last(chunks);
+
+    if (lastChunk![1] > end) {
+      lastChunk![1] = end;
+    }
 
     const requests = chunks
       .map(([chunkStart, chunkEnd]) => ({
@@ -152,9 +154,9 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
       }))
       .map(params => context!.datapoints.retrieve(params));
 
-    const results: DatapointsGetAggregateDatapoint[][] = await Promise.all(
+    const results: DatapointsGetAggregateDatapoint[][] = (await Promise.all(
       requests
-    );
+    )) as DatapointsGetAggregateDatapoint[][];
 
     return results.reduce((result, datapointsChunk) => {
       return result.map((dp, index) => {


### PR DESCRIPTION
Use seriesNumber in datapoints fetching instead of only timeseriesIds.length

I'm opening a PR from the newest version in v1.x, since updating to v2.x needs SDK v3 which will break insight.
This change is identical to the one on v2.x, just without needing the new SDK version

I'm unsure which branch to merge to though, to get a version 1.21 out that we can use in Insight :)