### PR TITLE
fix(timeseries-data-export): fix duplicate datapoints

### DIFF
--- a/.github/workflows/build_n_test.yml
+++ b/.github/workflows/build_n_test.yml
@@ -52,7 +52,7 @@ jobs:
         encrypted_5b5408a8dfc4_key: ${{ secrets.ENCRYPTED_5B5408A8DFC4_KEY }}
         encrypted_5b5408a8dfc4_iv: ${{ secrets.ENCRYPTED_5B5408A8DFC4_IV }}
       run: |
-        PR_ID=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+        PR_ID=$(echo $GITHUB_HEAD_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
         openssl aes-256-cbc -K $encrypted_5b5408a8dfc4_key -iv $encrypted_5b5408a8dfc4_iv \
         -in gcs-service-account.json.enc -out gcs-service-account.json -d
         GOOGLE_APPLICATION_CREDENTIALS=gcs-service-account.json preview upload storybook-static "gearboxjs/pr-${PR_ID}" && \

--- a/.github/workflows/build_n_test.yml
+++ b/.github/workflows/build_n_test.yml
@@ -46,7 +46,7 @@ jobs:
     - uses: codecov/codecov-action@v1
     - run: yarn build-storybook
     - name: Deploy preview
-      if: ${{ github.event_name == 'pull_request_target' }}
+      if: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         encrypted_5b5408a8dfc4_key: ${{ secrets.ENCRYPTED_5B5408A8DFC4_KEY }}

--- a/.github/workflows/build_n_test.yml
+++ b/.github/workflows/build_n_test.yml
@@ -46,13 +46,13 @@ jobs:
     - uses: codecov/codecov-action@v1
     - run: yarn build-storybook
     - name: Deploy preview
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request_target' }}
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         encrypted_5b5408a8dfc4_key: ${{ secrets.ENCRYPTED_5B5408A8DFC4_KEY }}
         encrypted_5b5408a8dfc4_iv: ${{ secrets.ENCRYPTED_5B5408A8DFC4_IV }}
       run: |
-        PR_ID=$(echo $GITHUB_HEAD_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+        PR_ID=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
         openssl aes-256-cbc -K $encrypted_5b5408a8dfc4_key -iv $encrypted_5b5408a8dfc4_iv \
         -in gcs-service-account.json.enc -out gcs-service-account.json -d
         GOOGLE_APPLICATION_CREDENTIALS=gcs-service-account.json preview upload storybook-static "gearboxjs/pr-${PR_ID}" && \

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
@@ -140,7 +140,9 @@ describe('TimeseriesDataExport', () => {
 
     const expectedLimit = Math.floor(apiDatapointsLimit / seriesNumber);
     expect(limit).toEqual(expectedLimit);
-    expect(chunkEnd - chunkStart).toEqual(expectedLimit * granularity);
+    expect(chunkEnd - chunkStart + granularity).toEqual(
+      expectedLimit * granularity
+    );
   });
 
   it('should trigger onSuccess callback if provided', async () => {

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
@@ -141,7 +141,9 @@ describe('TimeseriesDataExport', () => {
     const expectedLimit = Math.floor(apiDatapointsLimit / seriesNumber);
 
     expect(limit).toEqual(expectedLimit);
-    expect(chunkEnd - chunkStart + 1).toEqual(expectedLimit * granularity);
+    expect(chunkEnd - chunkStart - granularity).toEqual(
+      expectedLimit * granularity
+    );
   });
 
   it('should trigger onSuccess callback if provided', async () => {

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.test.tsx
@@ -139,11 +139,8 @@ describe('TimeseriesDataExport', () => {
     } = sdk.datapoints.retrieve.mock.calls[1][0];
 
     const expectedLimit = Math.floor(apiDatapointsLimit / seriesNumber);
-
     expect(limit).toEqual(expectedLimit);
-    expect(chunkEnd - chunkStart - granularity).toEqual(
-      expectedLimit * granularity
-    );
+    expect(chunkEnd - chunkStart).toEqual(expectedLimit * granularity);
   });
 
   it('should trigger onSuccess callback if provided', async () => {

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -137,7 +137,10 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
     const msPerRequest = limit * numericGranularity;
 
     const ranges = range(start, end, msPerRequest);
-    const chunks = ranges.map(range => [range, range + msPerRequest - 1]);
+    const chunks = ranges.map(range => [
+      range,
+      range + msPerRequest - numericGranularity,
+    ]);
     const lastChunk = last(chunks);
 
     if (lastChunk![1] > end) {


### PR DESCRIPTION
The previous implementation would sometimes fetch duplicate datapoints between ranges causing `arrangeDatapointsByTimestamp` to exclude subsequent datapoints.