### PR TITLE
feat(timeseries-data-export): form selection props

### DIFF
--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -59,6 +59,10 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
     onSuccess,
     strings = defaultStrings,
     labelFormatter,
+    defaultFormSelections = {
+      readableDataChecked: false,
+      selectedDelimiter: Delimiters.Comma,
+    },
   } = props;
   const context = useCogniteContext(Component, true);
   const [loading, setLoading] = useState(false);
@@ -320,6 +324,7 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
         >
           {getFieldDecorator('readableDate', {
             valuePropName: 'checked',
+            initialValue: defaultFormSelections.readableDataChecked,
           })(<Checkbox />)}
         </Form.Item>
         <Form.Item
@@ -328,7 +333,7 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
           help={delimiterHelp}
         >
           {getFieldDecorator('delimiter', {
-            initialValue: ',',
+            initialValue: defaultFormSelections.selectedDelimiter,
             rules: [{ required: true }],
           })(
             <Radio.Group>

--- a/src/components/TimeseriesDataExport/interfaces.ts
+++ b/src/components/TimeseriesDataExport/interfaces.ts
@@ -38,6 +38,11 @@ export interface TimeseriesDataExportFormFields {
   readableDate: boolean;
 }
 
+export interface DefaultSelections {
+  readableDataChecked: boolean;
+  selectedDelimiter: Delimiters;
+}
+
 export interface TimeseriesDataExportProps {
   /**
    * Array of timeserie ids
@@ -103,6 +108,10 @@ export interface TimeseriesDataExportProps {
    * Strings, that can be customized
    */
   strings?: ((defaultStrings: Strings) => Partial<Strings>) | Partial<Strings>;
+  /**
+   * Fields that can have a default state set
+   */
+  defaultFormSelections?: Partial<DefaultSelections>;
   /**
    * @ignore
    */

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,4 +25,5 @@ export * from './components/TimeseriesPreview';
 export * from './components/EventsTimeline';
 export * from './components/GlobalSearch';
 export * from './utils/documents';
+export * from './utils/csv';
 export * from './interfaces';


### PR DESCRIPTION
New prop that allows to pass in optional default selections for some of the export dialog form fields. 