### PR TITLE
fix: add guard/default to avoid accessing undefined [OI-2736] (v1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.20.2 (2020-12-01)
+
+
+### Bug Fixes
+
+* **timeseries-data-export:** add guard/default to avoid accessing undefined ([#686](https://github.com/cognitedata/gearbox.js/issues/686))
+
 ## 1.20.1 (2020-08-26)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/gearbox",
-  "version": "1.20.1",
+  "version": "1.20.2",
   "description": "GearBox will be a place for application developers to contribute useful, reusable components across applications",
   "contributors": [],
   "main": "dist/index.js",

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -171,7 +171,9 @@ const TimeseriesDataExportFC: FC<TimeseriesDataExportFormProps> = (
   };
 
   const getTimestamps = (arr: { datapoints: GetDatapointMetadata[] }[]) => {
-    return arr.map(({ datapoints: [item] }) => item.timestamp.getTime());
+    return arr
+      .filter(({ datapoints }) => datapoints.length)
+      .map(({ datapoints: [item] }) => item.timestamp.getTime());
   };
 
   const fetchCSVCall: FetchCSVCall = async (


### PR DESCRIPTION
Cherry pick from #679.

Is it possible to do a release for 1.x? We're not able to upgrade Insight to use 2.x in at the moment (it still uses v2 of the SDK).
