### PR TITLE
fix(timeseries-data-export): space instead of underscore in date format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.20.3 (2020-12-02)
+
+
+### Bug Fixes
+
+* **timeseries-data-export:** change date export format to support MS Excel ([#687](https://github.com/cognitedata/gearbox.js/pull/687))
+
 ## 1.20.2 (2020-12-01)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cognite/gearbox",
-  "version": "1.20.2",
+  "version": "1.20.3",
   "description": "GearBox will be a place for application developers to contribute useful, reusable components across applications",
   "contributors": [],
   "main": "dist/index.js",

--- a/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
+++ b/src/components/TimeseriesDataExport/TimeseriesDataExport.tsx
@@ -33,7 +33,7 @@ type TimeseriesDataExportFormProps = TimeseriesDataExportProps &
 // TODO: Check tree shaking for TimeseriesDataExport component
 const { RangePicker } = DatePicker;
 const CELL_LIMIT = 10000;
-const formatData = 'YYYY-MM-DD_HH:mm:ss';
+const formatData = 'YYYY-MM-DD HH:mm:ss';
 const formItemLayoutDefault: FormItemLayout = {
   labelCol: { xs: { span: 24 }, sm: { span: 8 } },
   wrapperCol: { xs: { span: 24 }, sm: { span: 16 } },

--- a/src/components/TimeseriesDataExport/constants.ts
+++ b/src/components/TimeseriesDataExport/constants.ts
@@ -4,7 +4,7 @@ export const defaultStrings = {
   labelGranularity: 'Label Granularity',
   labelGranularityHelp: 'Example inputs: 15s, 1m, 5h, 2d',
   formatTimestamp: 'Format timestamp?',
-  formatTimestampHelp: 'e.g. 2018-04-02_12:20:20',
+  formatTimestampHelp: 'e.g. 2018-04-02 12:20:20',
   delimiterLabel: 'Select delimiter',
   delimiterHelp: 'The character that will separate your data fields',
   csvDownload: 'Download as CSV',


### PR DESCRIPTION
[OI-2717](https://cognitedata.atlassian.net/browse/OI-2717) Customer complaining about date format not working as expected in MS Excel - wants the old format without `_`.

The immediate need is on the v1 branch, as the issue is reported for Insight (ADI).

Should I make a PR for v2 as well?

Ref to when it was changed initially: https://github.com/cognitedata/gearbox.js/pull/647#discussion_r422651953