### PR TITLE
fix(svg-viewer): allow specifying initial zoom as prop

### DIFF
--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -541,9 +541,8 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
     if (!currentAsset || !this.pinchZoomInstance) {
       return;
     }
-    this.pinchZoomInstance.zoomFactor = isDesktop
-      ? zoomLevel * 3
-      : zoomLevel * 10;
+    const defaultZoom = isDesktop ? zoomLevel * 3 : zoomLevel * 10;
+    this.pinchZoomInstance.zoomFactor = this.props.initialZoom || defaultZoom;
     // Need to wait until zoom applies to get proper offsets
     setTimeout(() => {
       const currentAssetPosition = currentAsset.getBoundingClientRect();

--- a/src/components/SVGViewer/interfaces.ts
+++ b/src/components/SVGViewer/interfaces.ts
@@ -65,6 +65,10 @@ interface SvgViewerBasicProps {
    */
   minZoom?: number;
   /**
+   * Initial zoom when the svg viewer is first opened
+   */
+  initialZoom?: number;
+  /**
    * Condition to locate and highlight current asset during first render
    */
   isCurrentAsset?: (metadataNode: Element) => boolean;


### PR DESCRIPTION
Allow specifying a custom initial zoom level. Since we allow customising min and max zoom limit, it may possibly be the case that the default zoom is outside of the limits - and that causes some jarring behaviour when zooming. 

Relates to [INFIELD-1981]

[INFIELD-1981]: https://cognitedata.atlassian.net/browse/INFIELD-1981