### PR TITLE
Fix: call play after setting srcObject in WebCam

### DIFF
--- a/src/components/AssetScanner/Webcam/Webcam.tsx
+++ b/src/components/AssetScanner/Webcam/Webcam.tsx
@@ -145,6 +145,7 @@ export class Webcam extends Component<WebcamProps, WebcamState> {
 
       if (this.video) {
         this.video.srcObject = stream;
+        this.video.play();
       }
 
       this.setState({


### PR DESCRIPTION
Asset scanner stopped working after users updated Edge's version and it is now required to explicitly tell the videoElement to `play()` after changing the srcObject stream.

More info here: 
[Microsoft Edge 92 won't autoplay all media anymore by default](https://www.ghacks.net/2021/07/25/microsoft-edge-92-wont-autoplay-all-media-anymore-by-default/)

Fixes [INFIELD-2594]

[INFIELD-2594]: https://cognitedata.atlassian.net/browse/INFIELD-2594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ