### PR TITLE
fix(performance): prevents setCustomClasses being called constantly

### DIFF
--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -86,10 +86,6 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
     const { maxZoom: prevMax, minZoom: prevMin } = prevProps;
     const { maxZoom: currMax, minZoom: currMin } = this.props;
 
-    if (this.svg) {
-      this.setCustomClasses();
-    }
-
     if (
       (currDocId !== undefined && currDocId !== prevDocId) ||
       (currFile !== undefined && currFile !== prevFile) ||
@@ -269,7 +265,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
       }
     } catch (e) {
       if (this.props.handleDocumentLoadError) {
-        this.props.handleDocumentLoadError(e);
+        this.props.handleDocumentLoadError(e as Error);
       }
     }
     if (svgString) {
@@ -541,7 +537,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
     if (!currentAsset || !this.pinchZoomInstance) {
       return;
     }
-    const defaultZoom = isDesktop ? zoomLevel * 3 : zoomLevel * 10;
+    const defaultZoom = isDesktop ? zoomLevel * 5 : zoomLevel * 10;
     this.pinchZoomInstance.zoomFactor = this.props.initialZoom || defaultZoom;
     // Need to wait until zoom applies to get proper offsets
     setTimeout(() => {


### PR DESCRIPTION
Partly fixes: https://cognitedata.atlassian.net/browse/INFIELD-2380 

I'm removing the call to `setCustomClasses() ` inside `componentDidUpdate` because it was being called regardless of the prev vs curr props difference. On the other hand, this.presetSVG() is in fact being called properly after considering the changes between prev and curr props and setCustomClasses() is being called from there again make the deleted call, redundant.