### PR TITLE
fix(svgviewer): execute all passed conditions

### DIFF
--- a/src/components/SVGViewer/interfaces.ts
+++ b/src/components/SVGViewer/interfaces.ts
@@ -38,6 +38,8 @@ export interface PinchZoomInterface {
 interface SvgViewerBasicProps {
   /**
    * List of classes and conditions on when they should be applied for equipment
+   * When condition returns `true` for <metadata> element,
+   * passed className is applied to '.metadata-container' element
    */
   metadataClassesConditions?: Conditions[];
   /**


### PR DESCRIPTION
[previous changes ](https://github.com/cognitedata/gearbox.js/pull/730) had a [mistake](https://github.com/cognitedata/gearbox.js/pull/730/files#diff-23b593734827286577a091e3c2f550964f5853adf83e063e3cea92a7a6b6a701R503) in condition execution algorithm, the mistake was to iterate through + remove elements from the same array at the same time. Doesn't happen anymore. Performance is still good though. 