### PR TITLE
fix(svgviewer): don't ignore customClassNames.currentAsset

### DIFF
--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -478,6 +478,9 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
       className: string;
     }[]
   ) => {
+    if (!metadataClassesAndConditions.length) {
+      return;
+    }
     const metadataContainers = this.svg.querySelectorAll('.metadata-container');
     metadataContainers.forEach(metaContainer => {
       // reset classes in case this method is being called more than once for the same document
@@ -490,30 +493,13 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
         metaContainer.querySelectorAll('metadata')
       );
 
-      // for the sake of performance we need to execute conditions as little as possible, to achieve it:
-      // - we don't execute condition for a metadata el if condition was met before
-      // - we don't iterate metadata anymore if all conditions are met
-      const unmetConditions = [...metadataClassesAndConditions];
-
-      for (const metadataElement of metadataElements) {
-        if (!unmetConditions.length) {
-          // metadataContainer satisfies to all passed conditions, nothing left to look for
-          break;
-        }
-
-        let unmetConditionIndex = 0;
-        while (unmetConditionIndex < unmetConditions.length) {
-          const { condition, className } = unmetConditions[unmetConditionIndex];
-          if (condition(metadataElement)) {
-            metaContainer.classList.add(className);
-            unmetConditions.splice(unmetConditionIndex, 1);
-            // no need to increment because we removed current element,
-            // so next iteration will have another element or exit
-          } else {
-            unmetConditionIndex++;
-          }
-        }
-      }
+      metadataClassesAndConditions
+        .filter(({ condition }) =>
+          // check if any metadataElement satisfies condition,
+          // one is enough to put className on the metadata container
+          metadataElements.some(condition)
+        )
+        .forEach(({ className }) => metaContainer.classList.add(className));
     });
   };
 

--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -22,7 +22,7 @@ import { getDocumentDownloadLink } from './utils';
 
 const zoomLevel = 0.7;
 const wheelZoomLevel = 0.15;
-const currentAssetClassName = 'current-asset';
+const defaultCurrentAssetClassName = 'current-asset';
 const minDesktopWidth = 992;
 
 interface SvgViewerState {
@@ -272,8 +272,14 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
     });
   };
 
+  getCurrentAssetClassName = () => {
+    return (
+      (this.props.customClassNames || {}).currentAsset ||
+      defaultCurrentAssetClassName
+    );
+  };
+
   presetSVG = async () => {
-    const { customClassNames } = this.props;
     let svgString;
     try {
       const { documentId } = this.props as SvgViewerDocumentIdProps;
@@ -309,7 +315,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
         this.setCustomClasses();
         this.svg.addEventListener('click', this.handleItemClick);
         const currentAssetElement = document.querySelector(
-          `.${currentAssetClassName || (customClassNames || {}).currentAsset}`
+          `.${this.getCurrentAssetClassName()}`
         )!;
         this.zoomOnCurrentAsset(currentAssetElement);
       }
@@ -323,9 +329,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
     if (this.props.isCurrentAsset) {
       classesAndConditions.push({
         condition: this.props.isCurrentAsset,
-        className:
-          currentAssetClassName ||
-          (this.props.customClassNames || {}).currentAsset,
+        className: this.getCurrentAssetClassName(),
       });
     }
 
@@ -819,7 +823,7 @@ const SvgNode = styled.div`
     ${(props: InternalThemedStyledProps) =>
       !props.customClassNames.currentAsset &&
       `
-    &.current-asset {
+    &.${defaultCurrentAssetClassName} {
       outline: auto 2px #36a2c2;
       cursor: default;
       > {

--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -317,22 +317,19 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
   };
 
   setCustomClasses = () => {
+    const classesAndConditions = [
+      ...(this.props.metadataClassesConditions || []),
+    ];
     if (this.props.isCurrentAsset) {
-      this.addCssClassesToMetadataContainer({
+      classesAndConditions.push({
         condition: this.props.isCurrentAsset,
         className:
           currentAssetClassName ||
           (this.props.customClassNames || {}).currentAsset,
       });
     }
-    if (
-      this.props.metadataClassesConditions &&
-      this.props.metadataClassesConditions.length
-    ) {
-      this.addBulkClassesToMetadataContainer(
-        this.props.metadataClassesConditions
-      );
-    }
+
+    this.addBulkClassesToMetadataContainer(classesAndConditions);
   };
 
   initiateScale = () => {

--- a/src/components/SVGViewer/__tests__/SVGViewer.test.tsx
+++ b/src/components/SVGViewer/__tests__/SVGViewer.test.tsx
@@ -25,7 +25,7 @@ const sdk = new CogniteClient({ appId: 'gearbox test' });
 // and used string parsing of html() that correctly contains svg
 const hasStringExactlyOnce = (source: string, search: string) => {
   return (
-    source.indexOf(search) > -1 &&
+    source.includes(search) &&
     source.indexOf(search) === source.lastIndexOf(search)
   );
 };

--- a/src/components/SVGViewer/__tests__/SVGViewer.test.tsx
+++ b/src/components/SVGViewer/__tests__/SVGViewer.test.tsx
@@ -21,6 +21,15 @@ class CogniteClient extends MockCogniteClient {
 
 const sdk = new CogniteClient({ appId: 'gearbox test' });
 
+// gave up on searching of svg elements within enzyme output
+// and used string parsing of html() that correctly contains svg
+const hasStringExactlyOnce = (source: string, search: string) => {
+  return (
+    source.indexOf(search) > -1 &&
+    source.indexOf(search) === source.lastIndexOf(search)
+  );
+};
+
 describe('SVGViewer', () => {
   it('Renders without exploding', () => {
     const wrapper = mount(
@@ -88,6 +97,40 @@ describe('SVGViewer', () => {
     );
   });
 
+  it('adds .current-asset class by default', () => {
+    const wrapper = mount(
+      <ClientSDKProvider client={sdk}>
+        <SVGViewer
+          file={`<svg><g class='metadata-container'><metadata></metadata></g></svg>`}
+          isCurrentAsset={() => true}
+        />
+      </ClientSDKProvider>
+    );
+
+    expect(hasStringExactlyOnce(wrapper.html(), 'current-asset')).toBe(true);
+  });
+
+  it('adds custom class for currentAsset when passed', () => {
+    const customCurrentAssetClassName = 'customCurrentAssetClassName';
+
+    const wrapper = mount(
+      <ClientSDKProvider client={sdk}>
+        <SVGViewer
+          file={`<svg><g class='metadata-container'><metadata></metadata></g></svg>`}
+          isCurrentAsset={() => true}
+          customClassNames={{
+            currentAsset: customCurrentAssetClassName,
+          }}
+        />
+      </ClientSDKProvider>
+    );
+
+    expect(hasStringExactlyOnce(wrapper.html(), 'current-asset')).toBe(false);
+    expect(
+      hasStringExactlyOnce(wrapper.html(), customCurrentAssetClassName)
+    ).toBe(true);
+  });
+
   describe('metadataClassesConditions tests', () => {
     const getConditionImplementation = (testId: number) => (meta: Element) => {
       const idEl = meta.querySelector('id');
@@ -95,15 +138,6 @@ describe('SVGViewer', () => {
         return false;
       }
       return Number(idEl.textContent) === testId;
-    };
-
-    // gave up on searching of svg elements within enzyme output
-    // and used string parsing of html() that correctly contains svg
-    const hasStringExactlyOnce = (source: string, search: string) => {
-      return (
-        source.indexOf(search) > -1 &&
-        source.indexOf(search) === source.lastIndexOf(search)
-      );
     };
 
     it('executes all the passed conditions', () => {


### PR DESCRIPTION
as promised [here](https://github.com/cognitedata/gearbox.js/pull/732#discussion_r761369229) applied refactoring suggestions for addBulkClassesToMetadataContainer method for better readability.

I tried to do some measurements, in both cases execution speed of `setCustomClasses` method is about 200ms (I used this [doc](https://infield.staging.cogniteapp.com/akerbp-test/iaa/asset/1021380559964264/docs#5570684871936905) and 6x CPU slow-down), so refactoring doesn't hurt performance in any way 🙂 