### PR TITLE
perf(svgviewer): optimize interactions on mobile [INFIELD-2696]

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "lodash": "^4.17.15",
     "ms": "^2.1.2",
     "numeral": "^2.0.6",
-    "pinch-zoom-js": "^2.3.4",
     "react-dnd": "^7.4.5",
     "react-dnd-html5-backend": "^7.4.4",
     "react-odometerjs": "^2.1.1",

--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -1,7 +1,7 @@
 // Copyright 2020 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import { Icon } from 'antd';
-import PinchZoom from 'pinch-zoom-js';
+import PinchZoom from './pinchzoom';
 import React, { Component, KeyboardEvent, RefObject } from 'react';
 import styled from 'styled-components';
 import { ERROR_NO_SDK_CLIENT } from '../../constants/errorMessages';
@@ -352,6 +352,8 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
     if (this.pinchZoom.current) {
       this.pinchZoom.current.innerHTML = '';
       this.pinchZoom.current.appendChild(this.svg);
+
+      // @ts-ignore
       this.pinchZoomInstance = new PinchZoom(this.pinchZoom.current, {
         animationDuration: 0,
         tapZoomFactor: 8,

--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -691,6 +691,7 @@ const SVGViewerContainer = styled.div`
   height: 100%;
   width: 100%;
   position: relative;
+  contain: strict;
 `;
 
 interface InternalThemedStyledProps {

--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -1,7 +1,7 @@
 // Copyright 2021 Cognite AS
 import { CogniteClient } from '@cognite/sdk';
 import { Icon } from 'antd';
-import PinchZoom from './pinchzoom';
+import { PinchZoom } from './pinchzoom';
 import React, { Component, KeyboardEvent } from 'react';
 import styled from 'styled-components';
 import { ERROR_NO_SDK_CLIENT } from '../../constants/errorMessages';
@@ -11,7 +11,6 @@ import DOMPurify from 'dompurify';
 
 import {
   CustomClassNames,
-  PinchZoomInterface,
   SvgViewerDocumentIdProps,
   SvgViewerFileProps,
   SvgViewerProps,
@@ -44,7 +43,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
   prevMoveDistanceY: number = 0;
   dragging: boolean = false;
   startMouse!: ZoomCenter;
-  pinchZoomInstance!: PinchZoomInterface;
+  pinchZoomInstance!: PinchZoom;
   svg!: SVGSVGElement;
   pinchZoom: React.RefObject<HTMLDivElement>;
   pinchZoomContainer: React.RefObject<HTMLDivElement>;
@@ -223,7 +222,6 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
           />
           {/* move pinchZoomContainer if search is visible on mobile */}
           <div
-            id={'pinchZoomContainer'}
             ref={this.pinchZoomContainer}
             style={
               !isDesktop && this.state.isSearchVisible
@@ -231,7 +229,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
                 : {}
             }
           >
-            <div ref={this.pinchZoom} id={'pinch-zoom'} />
+            <div ref={this.pinchZoom} />
           </div>
           {!isDesktop && !this.state.isSearchFocused ? (
             <ModalMobileFooter>
@@ -343,7 +341,6 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
       this.pinchZoom.current.innerHTML = '';
       this.pinchZoom.current.appendChild(this.svg);
 
-      // @ts-ignore
       this.pinchZoomInstance = new PinchZoom(this.pinchZoom.current, {
         animationDuration: 0,
         tapZoomFactor: 8,

--- a/src/components/SVGViewer/SVGViewer.tsx
+++ b/src/components/SVGViewer/SVGViewer.tsx
@@ -120,9 +120,21 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
     } = this.props;
     const { isDesktop } = this.state;
     const hasCloseButton = !!this.props.handleCancel;
-
     return (
-      <SVGViewerContainer onKeyDown={this.handleKeyDown} tabIndex={0}>
+      <SVGViewerContainer
+        onKeyDown={this.handleKeyDown}
+        tabIndex={0}
+        onFocus={() => {
+          if (this.pinchZoom.current) {
+            this.pinchZoom.current.style.willChange = 'transform';
+          }
+        }}
+        onBlur={() => {
+          if (this.pinchZoom.current) {
+            this.pinchZoom.current.style.willChange = 'auto';
+          }
+        }}
+      >
         <SvgNode
           ref={this.svgParentNode}
           onMouseDown={this.onMouseDown}
@@ -211,6 +223,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
           />
           {/* move pinchZoomContainer if search is visible on mobile */}
           <div
+            id={'pinchZoomContainer'}
             ref={this.pinchZoomContainer}
             style={
               !isDesktop && this.state.isSearchVisible
@@ -218,11 +231,7 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
                 : {}
             }
           >
-            <div
-              ref={this.pinchZoom}
-              onTouchStart={this.onTouchStart}
-              onTouchEnd={this.onTouchEnd}
-            />
+            <div ref={this.pinchZoom} id={'pinch-zoom'} />
           </div>
           {!isDesktop && !this.state.isSearchFocused ? (
             <ModalMobileFooter>
@@ -413,23 +422,6 @@ export class SVGViewer extends Component<SvgViewerProps, SvgViewerState> {
     this.dragging = false;
     this.prevMoveDistanceX = 0;
     this.prevMoveDistanceY = 0;
-  };
-
-  // we need to remove and add back optimization as suggested here
-  // https://developer.mozilla.org/en-US/docs/Web/CSS/will-change
-  // so all the items will be rendered not blurry
-  onTouchStart = () => {
-    if (this.pinchZoom.current && !this.isOptimizationDisabled) {
-      // @ts-ignore 'willChange' is not a part of 'CSSStyleDeclaration'
-      this.pinchZoom.current.style.willChange = 'transform';
-    }
-  };
-
-  onTouchEnd = () => {
-    if (this.pinchZoom.current && !this.isOptimizationDisabled) {
-      // @ts-ignore 'willChange' is not a part of 'CSSStyleDeclaration'
-      this.pinchZoom.current.style.willChange = 'auto';
-    }
   };
 
   addCssClassesToMetadataContainer = ({

--- a/src/components/SVGViewer/pinchzoom.ts
+++ b/src/components/SVGViewer/pinchzoom.ts
@@ -585,7 +585,6 @@ const definePinchZoom = function() {
 
       this.container.style.overflow = 'hidden';
       this.container.style.position = 'relative';
-      this.container.style.contain = 'strict';
 
       this.el.style.transformOrigin = '0% 0%';
 

--- a/src/components/SVGViewer/pinchzoom.ts
+++ b/src/components/SVGViewer/pinchzoom.ts
@@ -226,7 +226,6 @@ const definePinchZoom = function() {
      * @return {Object} the sanitized offset
      */
     sanitizeOffset: function(offset) {
-      // fixme: slow reads
       const elWidth =
         this.el.offsetWidth * this.getInitialZoomFactor() * this.zoomFactor;
       const elHeight =
@@ -449,7 +448,6 @@ const definePinchZoom = function() {
      * @return {number} the initial zoom factor
      */
     getInitialZoomFactor: function() {
-      // fixme: slow read
       const xZoomFactor = this.container.offsetWidth / this.el.offsetWidth;
       const yZoomFactor = this.container.offsetHeight / this.el.offsetHeight;
 
@@ -491,7 +489,6 @@ const definePinchZoom = function() {
      */
     getTouches: function(event) {
       const rect = this.container.getBoundingClientRect();
-      // TODO: slow reads
       const scrollTop =
         document.documentElement.scrollTop || document.body.scrollTop;
       const scrollLeft =
@@ -499,7 +496,6 @@ const definePinchZoom = function() {
       const posTop = rect.top + scrollTop;
       const posLeft = rect.left + scrollLeft;
 
-      // TODO slow touch.pageX, pageY ?
       return Array.prototype.slice.call(event.touches).map(function(touch) {
         return {
           x: touch.pageX - posLeft,
@@ -517,12 +513,12 @@ const definePinchZoom = function() {
      * @param callback
      */
     animate: function(duration, framefn, timefn, callback) {
-      var startTime = new Date().getTime(),
+      var startTime = Date.now(),
         renderFrame = function() {
           if (!this.inAnimation) {
             return;
           }
-          let frameTime = new Date().getTime() - startTime,
+          let frameTime = Date.now() - startTime,
             progress = frameTime / duration;
           if (frameTime >= duration) {
             framefn(1);
@@ -591,10 +587,6 @@ const definePinchZoom = function() {
       this.container.style.position = 'relative';
       this.container.style.contain = 'strict';
 
-      this.el.style.webkitTransformOrigin = '0% 0%';
-      this.el.style.mozTransformOrigin = '0% 0%';
-      this.el.style.msTransformOrigin = '0% 0%';
-      this.el.style.oTransformOrigin = '0% 0%';
       this.el.style.transformOrigin = '0% 0%';
 
       this.el.style.position = 'absolute';
@@ -648,37 +640,8 @@ const definePinchZoom = function() {
 
          const zoomFactor = this.getInitialZoomFactor() * this.zoomFactor,
            offsetX = -this.offset.x / zoomFactor,
-           offsetY = -this.offset.y / zoomFactor,
-           transform3d =
-             'scale3d(' +
-             zoomFactor +
-             ', ' +
-             zoomFactor +
-             ',1) ' +
-             'translate3d(' +
-             offsetX +
-             'px,' +
-             offsetY +
-             'px,0px)',
-           transform2d =
-             'scale(' +
-             zoomFactor +
-             ', ' +
-             zoomFactor +
-             ') ' +
-             'translate(' +
-             offsetX +
-             'px,' +
-             offsetY +
-             'px)';
-
-         // TODO: takes a lot of time to set this one
-         // todo: do we need 3d here?
-         this.el.style.webkitTransform = transform3d;
-         this.el.style.mozTransform = transform2d;
-         this.el.style.msTransform = transform2d;
-         this.el.style.oTransform = transform2d;
-         this.el.style.transform = transform3d;
+           offsetY = -this.offset.y / zoomFactor;
+         this.el.style.transform = `scale(${zoomFactor}, ${zoomFactor}) translate(${offsetX}px, ${offsetY}px)`;
        }
       );
     },
@@ -738,7 +701,6 @@ const definePinchZoom = function() {
       },
       targetTouches = function(touches) {
         return Array.from(touches).map(function(touch) {
-          // TODO slow read
           return {
             x: touch.pageX,
             y: touch.pageY,

--- a/src/components/SVGViewer/pinchzoom.ts
+++ b/src/components/SVGViewer/pinchzoom.ts
@@ -2,6 +2,8 @@
 
 // @ts-nocheck
 /* eslint-disable */
+// original code is take from here https://github.com/manuelstofer/pinchzoom
+// modified to optimize performance (removed root node cloning, some unused polyfils and vendor prefixes)
 
 const definePinchZoom = function() {
   /**

--- a/src/components/SVGViewer/pinchzoom.ts
+++ b/src/components/SVGViewer/pinchzoom.ts
@@ -1,816 +1,853 @@
 // Copyright 2021 Cognite AS
 
-// @ts-nocheck
-/* eslint-disable */
 // original code is take from here https://github.com/manuelstofer/pinchzoom
 // modified to optimize performance (removed root node cloning, some unused polyfils and vendor prefixes)
+// also ported to TS
 
-const definePinchZoom = function() {
+type Options = {
+  tapZoomFactor: number;
+  zoomOutFactor: number;
+  animationDuration: number;
+  maxZoom: number;
+  minZoom: number;
+  draggableUnzoomed: boolean;
+  lockDragAxis: boolean;
+  setOffsetsOnce: boolean;
+  use2d: boolean;
+  verticalPadding: number;
+  horizontalPadding: number;
+  onZoomStart?: ((...args: any) => unknown) | null;
+  onZoomEnd?: ((...args: any) => unknown) | null;
+  onZoomUpdate?: ((...args: any) => unknown) | null;
+  onDragStart?: ((...args: any) => unknown) | null;
+  onDragEnd?: ((...args: any) => unknown) | null;
+  onDragUpdate?: ((...args: any) => unknown) | null;
+  onDoubleTap?: ((...args: any) => unknown) | null;
+};
+type Coordinates = { x: number; y: number };
+const defaultOptions: Options = {
+  tapZoomFactor: 2,
+  zoomOutFactor: 1.3,
+  animationDuration: 300,
+  maxZoom: 4,
+  minZoom: 0.5,
+  draggableUnzoomed: true,
+  lockDragAxis: false,
+  setOffsetsOnce: false,
+  use2d: true,
+  verticalPadding: 0,
+  horizontalPadding: 0,
+  onZoomStart: null,
+  onZoomEnd: null,
+  onZoomUpdate: null,
+  onDragStart: null,
+  onDragEnd: null,
+  onDragUpdate: null,
+  onDoubleTap: null,
+};
+
+export default class PinchZoom {
+  // making everything public as it was all public originally and used by SVG viewer
+  public el: HTMLElement;
+  public container = document.createElement('div');
+  public zoomFactor = 1;
+  public lastScale = 1;
+  public offset = {
+    x: 0,
+    y: 0,
+  };
+  public initialOffset = {
+    x: 0,
+    y: 0,
+  };
+  public options: Options;
+  public isDoubleTap = false;
+  public enabled = false;
+
+  private lastDragPosition: Coordinates | null = null;
+  private lastZoomCenter: Coordinates | null = null;
+  private hasInteraction = false;
+  private nthZoom = 0;
+  private updatePlanned = false;
+  private inAnimation = false;
+  private _isOffsetsSet = false;
+
+  constructor(el: HTMLElement, options: Partial<Options>) {
+    this.el = el;
+
+    this.options = Object.assign({}, defaultOptions, options);
+    this.setupMarkup();
+    this.bindEvents();
+    this.update();
+
+    // The image may already be loaded when PinchZoom is initialized,
+    // and then the load event (which trigger update) will never fire.
+    if (this.isImageLoaded(this.el)) {
+      this.updateAspectRatio();
+      this.setupOffsets();
+    }
+
+    this.enable();
+  }
+
+  public isCloseTo(value: number, expected: number) {
+    return value > expected - 0.01 && value < expected + 0.01;
+  }
+
   /**
-   * Pinch zoom
-   * @param el
-   * @param options
-   * @constructor
+   * Event handler for 'dragstart'
+   * @param event
    */
-  const PinchZoom = function(el, options) {
-      this.el = el;
-      this.zoomFactor = 1;
-      this.lastScale = 1;
-      this.offset = {
-        x: 0,
-        y: 0,
-      };
-      this.initialOffset = {
-        x: 0,
-        y: 0,
-      };
-      this.options = Object.assign({}, this.defaults, options);
-      this.setupMarkup();
-      this.bindEvents();
-      this.update();
+  public handleDragStart(event: TouchEvent) {
+    if (typeof this.options.onDragStart == 'function') {
+      this.options.onDragStart(this, event);
+    }
+    this.stopAnimation();
+    this.lastDragPosition = null;
+    this.hasInteraction = true;
+    this.handleDrag(event);
+  }
 
-      // The image may already be loaded when PinchZoom is initialized,
-      // and then the load event (which trigger update) will never fire.
-      if (this.isImageLoaded(this.el)) {
-        this.updateAspectRatio();
-        this.setupOffsets();
-      }
+  /**
+   * Event handler for 'drag'
+   * @param event
+   */
+  public handleDrag(event: TouchEvent) {
+    const touch = this.getTouches(event)[0];
+    this.drag(touch, this.lastDragPosition);
+    this.offset = this.sanitizeOffset(this.offset);
+    this.lastDragPosition = touch;
+  }
 
-      this.enable();
-    },
-    sum = function(a, b) {
-      return a + b;
-    },
-    isCloseTo = function(value, expected) {
-      return value > expected - 0.01 && value < expected + 0.01;
+  public handleDragEnd(event: TouchEvent) {
+    if (typeof this.options.onDragEnd == 'function') {
+      this.options.onDragEnd(this, event);
+    }
+    this.end();
+  }
+
+  /**
+   * Event handler for 'zoomstart'
+   * @param event
+   */
+  public handleZoomStart(event: TouchEvent) {
+    if (typeof this.options.onZoomStart == 'function') {
+      this.options.onZoomStart(this, event);
+    }
+    this.stopAnimation();
+    this.lastScale = 1;
+    this.nthZoom = 0;
+    this.lastZoomCenter = null;
+    this.hasInteraction = true;
+  }
+
+  /**
+   * Event handler for 'zoom'
+   * @param event
+   * @param newScale
+   */
+  public handleZoom(event: TouchEvent, newScale: number) {
+    // a relative scale factor is used
+    const touchCenter = this.getTouchCenter(this.getTouches(event)),
+      scale = newScale / this.lastScale;
+    this.lastScale = newScale;
+
+    // the first touch events are thrown away since they are not precise
+    this.nthZoom += 1;
+    if (this.nthZoom > 3) {
+      this.scale(scale, touchCenter);
+      this.drag(touchCenter, this.lastZoomCenter);
+    }
+    this.lastZoomCenter = touchCenter;
+  }
+
+  public handleZoomEnd(event: TouchEvent) {
+    if (typeof this.options.onZoomEnd == 'function') {
+      this.options.onZoomEnd(this, event);
+    }
+    this.end();
+  }
+
+  /**
+   * Event handler for 'doubletap'
+   * @param event
+   */
+  public handleDoubleTap(event: TouchEvent) {
+    let center = this.getTouches(event)[0];
+    const zoomFactor = this.zoomFactor > 1 ? 1 : this.options.tapZoomFactor;
+    const startZoomFactor = this.zoomFactor;
+
+    const updateProgress = (progress: number) => {
+      this.scaleTo(
+        startZoomFactor + progress * (zoomFactor - startZoomFactor),
+        center
+      );
     };
 
-  PinchZoom.prototype = {
-    defaults: {
-      tapZoomFactor: 2,
-      zoomOutFactor: 1.3,
-      animationDuration: 300,
-      maxZoom: 4,
-      minZoom: 0.5,
-      draggableUnzoomed: true,
-      lockDragAxis: false,
-      setOffsetsOnce: false,
-      use2d: true,
-      verticalPadding: 0,
-      horizontalPadding: 0,
-      onZoomStart: null,
-      onZoomEnd: null,
-      onZoomUpdate: null,
-      onDragStart: null,
-      onDragEnd: null,
-      onDragUpdate: null,
-      onDoubleTap: null,
-    },
+    if (this.hasInteraction) {
+      return;
+    }
 
-    /**
-     * Event handler for 'dragstart'
-     * @param event
-     */
-    handleDragStart: function(event) {
-      if (typeof this.options.onDragStart == 'function') {
-        this.options.onDragStart(this, event);
-      }
-      this.stopAnimation();
-      this.lastDragPosition = false;
-      this.hasInteraction = true;
-      this.handleDrag(event);
-    },
+    this.isDoubleTap = true;
 
-    /**
-     * Event handler for 'drag'
-     * @param event
-     */
-    handleDrag: function(event) {
-      const touch = this.getTouches(event)[0];
-      this.drag(touch, this.lastDragPosition);
-      this.offset = this.sanitizeOffset(this.offset);
-      this.lastDragPosition = touch;
-    },
+    if (startZoomFactor > zoomFactor) {
+      center = this.getCurrentZoomCenter();
+    }
 
-    handleDragEnd: function() {
-      if (typeof this.options.onDragEnd == 'function') {
-        this.options.onDragEnd(this, event);
-      }
-      this.end();
-    },
+    this.animate(this.options.animationDuration, updateProgress, this.swing);
+    if (typeof this.options.onDoubleTap == 'function') {
+      this.options.onDoubleTap(this, event);
+    }
+  }
 
-    /**
-     * Event handler for 'zoomstart'
-     * @param event
-     */
-    handleZoomStart: function(event) {
-      if (typeof this.options.onZoomStart == 'function') {
-        this.options.onZoomStart(this, event);
-      }
-      this.stopAnimation();
-      this.lastScale = 1;
-      this.nthZoom = 0;
-      this.lastZoomCenter = false;
-      this.hasInteraction = true;
-    },
+  /**
+   * Compute the initial offset
+   *
+   * the element should be centered in the container upon initialization
+   */
+  public computeInitialOffset() {
+    this.initialOffset = {
+      x:
+        -Math.abs(
+          this.el.offsetWidth * this.getInitialZoomFactor() -
+            this.container.offsetWidth
+        ) / 2,
+      y:
+        -Math.abs(
+          this.el.offsetHeight * this.getInitialZoomFactor() -
+            this.container.offsetHeight
+        ) / 2,
+    };
+  }
 
-    /**
-     * Event handler for 'zoom'
-     * @param event
-     * @param newScale
-     */
-    handleZoom: function(event, newScale) {
-      // a relative scale factor is used
-      const touchCenter = this.getTouchCenter(this.getTouches(event)),
-        scale = newScale / this.lastScale;
-      this.lastScale = newScale;
+  /**
+   * Reset current image offset to that of the initial offset
+   */
+  public resetOffset() {
+    this.offset.x = this.initialOffset.x;
+    this.offset.y = this.initialOffset.y;
+  }
 
-      // the first touch events are thrown away since they are not precise
-      this.nthZoom += 1;
-      if (this.nthZoom > 3) {
-        this.scale(scale, touchCenter);
-        this.drag(touchCenter, this.lastZoomCenter);
-      }
-      this.lastZoomCenter = touchCenter;
-    },
+  /**
+   * Determine if image is loaded
+   */
+  public isImageLoaded(el: HTMLElement) {
+    if (el.nodeName === 'IMG') {
+      const imageEl = el as HTMLImageElement;
+      return imageEl.complete && imageEl.naturalHeight !== 0;
+    } else {
+      return Array.from(el.querySelectorAll('img')).every(this.isImageLoaded);
+    }
+  }
 
-    handleZoomEnd: function() {
-      if (typeof this.options.onZoomEnd == 'function') {
-        this.options.onZoomEnd(this, event);
-      }
-      this.end();
-    },
+  public setupOffsets() {
+    if (this.options.setOffsetsOnce && this._isOffsetsSet) {
+      return;
+    }
 
-    /**
-     * Event handler for 'doubletap'
-     * @param event
-     */
-    handleDoubleTap: function(event) {
-      let center = this.getTouches(event)[0],
-        zoomFactor = this.zoomFactor > 1 ? 1 : this.options.tapZoomFactor,
-        startZoomFactor = this.zoomFactor,
-        updateProgress = function(progress) {
-          this.scaleTo(
-            startZoomFactor + progress * (zoomFactor - startZoomFactor),
-            center
-          );
-        }.bind(this);
+    this._isOffsetsSet = true;
 
-      if (this.hasInteraction) {
-        return;
-      }
+    this.computeInitialOffset();
+    this.resetOffset();
+  }
 
-      this.isDoubleTap = true;
+  /**
+   * Max / min values for the offset
+   * @param offset
+   * @return {Object} the sanitized offset
+   */
+  public sanitizeOffset(offset: Coordinates) {
+    const elWidth =
+      this.el.offsetWidth * this.getInitialZoomFactor() * this.zoomFactor;
+    const elHeight =
+      this.el.offsetHeight * this.getInitialZoomFactor() * this.zoomFactor;
+    const maxX =
+        elWidth - this.getContainerX() + this.options.horizontalPadding,
+      maxY = elHeight - this.getContainerY() + this.options.verticalPadding,
+      maxOffsetX = Math.max(maxX, 0),
+      maxOffsetY = Math.max(maxY, 0),
+      minOffsetX = Math.min(maxX, 0) - this.options.horizontalPadding,
+      minOffsetY = Math.min(maxY, 0) - this.options.verticalPadding;
 
-      if (startZoomFactor > zoomFactor) {
-        center = this.getCurrentZoomCenter();
-      }
+    return {
+      x: Math.min(Math.max(offset.x, minOffsetX), maxOffsetX),
+      y: Math.min(Math.max(offset.y, minOffsetY), maxOffsetY),
+    };
+  }
 
-      this.animate(this.options.animationDuration, updateProgress, this.swing);
-      if (typeof this.options.onDoubleTap == 'function') {
-        this.options.onDoubleTap(this, event);
-      }
-    },
+  /**
+   * Scale to a specific zoom factor (not relative)
+   * @param zoomFactor
+   * @param center
+   */
+  public scaleTo(zoomFactor: number, center: Coordinates) {
+    this.scale(zoomFactor / this.zoomFactor, center);
+  }
 
-    /**
-     * Compute the initial offset
-     *
-     * the element should be centered in the container upon initialization
-     */
-    computeInitialOffset: function() {
-      this.initialOffset = {
-        x:
-          -Math.abs(
-            this.el.offsetWidth * this.getInitialZoomFactor() -
-              this.container.offsetWidth
-          ) / 2,
-        y:
-          -Math.abs(
-            this.el.offsetHeight * this.getInitialZoomFactor() -
-              this.container.offsetHeight
-          ) / 2,
-      };
-    },
+  /**
+   * Scales the element from specified center
+   * @param scale
+   * @param center
+   */
+  public scale(scale: number, center: Coordinates) {
+    scale = this.scaleZoomFactor(scale);
+    this.addOffset({
+      x: (scale - 1) * (center.x + this.offset.x),
+      y: (scale - 1) * (center.y + this.offset.y),
+    });
+    if (typeof this.options.onZoomUpdate == 'function') {
+      this.options.onZoomUpdate(this, event);
+    }
+  }
 
-    /**
-     * Reset current image offset to that of the initial offset
-     */
-    resetOffset: function() {
-      this.offset.x = this.initialOffset.x;
-      this.offset.y = this.initialOffset.y;
-    },
+  /**
+   * Scales the zoom factor relative to current state
+   * @param scale
+   * @return the actual scale (can differ because of max min zoom factor)
+   */
+  public scaleZoomFactor(scale: number) {
+    const originalZoomFactor = this.zoomFactor;
+    this.zoomFactor *= scale;
+    this.zoomFactor = Math.min(
+      this.options.maxZoom,
+      Math.max(this.zoomFactor, this.options.minZoom)
+    );
+    return this.zoomFactor / originalZoomFactor;
+  }
 
-    /**
-     * Determine if image is loaded
-     */
-    isImageLoaded: function(el) {
-      if (el.nodeName === 'IMG') {
-        return el.complete && el.naturalHeight !== 0;
-      } else {
-        return Array.from(el.querySelectorAll('img')).every(this.isImageLoaded);
-      }
-    },
+  /**
+   * Determine if the image is in a draggable state
+   *
+   * When the image can be dragged, the drag event is acted upon and cancelled.
+   * When not draggable, the drag event bubbles through this component.
+   *
+   * @return {Boolean}
+   */
+  public canDrag() {
+    return (
+      this.options.draggableUnzoomed || !this.isCloseTo(this.zoomFactor, 1)
+    );
+  }
 
-    setupOffsets: function() {
-      if (this.options.setOffsetsOnce && this._isOffsetsSet) {
-        return;
-      }
-
-      this._isOffsetsSet = true;
-
-      this.computeInitialOffset();
-      this.resetOffset();
-    },
-
-    /**
-     * Max / min values for the offset
-     * @param offset
-     * @return {Object} the sanitized offset
-     */
-    sanitizeOffset: function(offset) {
-      const elWidth =
-        this.el.offsetWidth * this.getInitialZoomFactor() * this.zoomFactor;
-      const elHeight =
-        this.el.offsetHeight * this.getInitialZoomFactor() * this.zoomFactor;
-      const maxX =
-          elWidth - this.getContainerX() + this.options.horizontalPadding,
-        maxY = elHeight - this.getContainerY() + this.options.verticalPadding,
-        maxOffsetX = Math.max(maxX, 0),
-        maxOffsetY = Math.max(maxY, 0),
-        minOffsetX = Math.min(maxX, 0) - this.options.horizontalPadding,
-        minOffsetY = Math.min(maxY, 0) - this.options.verticalPadding;
-
-      return {
-        x: Math.min(Math.max(offset.x, minOffsetX), maxOffsetX),
-        y: Math.min(Math.max(offset.y, minOffsetY), maxOffsetY),
-      };
-    },
-
-    /**
-     * Scale to a specific zoom factor (not relative)
-     * @param zoomFactor
-     * @param center
-     */
-    scaleTo: function(zoomFactor, center) {
-      this.scale(zoomFactor / this.zoomFactor, center);
-    },
-
-    /**
-     * Scales the element from specified center
-     * @param scale
-     * @param center
-     */
-    scale: function(scale, center) {
-      scale = this.scaleZoomFactor(scale);
-      this.addOffset({
-        x: (scale - 1) * (center.x + this.offset.x),
-        y: (scale - 1) * (center.y + this.offset.y),
-      });
-      if (typeof this.options.onZoomUpdate == 'function') {
-        this.options.onZoomUpdate(this, event);
-      }
-    },
-
-    /**
-     * Scales the zoom factor relative to current state
-     * @param scale
-     * @return the actual scale (can differ because of max min zoom factor)
-     */
-    scaleZoomFactor: function(scale) {
-      const originalZoomFactor = this.zoomFactor;
-      this.zoomFactor *= scale;
-      this.zoomFactor = Math.min(
-        this.options.maxZoom,
-        Math.max(this.zoomFactor, this.options.minZoom)
-      );
-      return this.zoomFactor / originalZoomFactor;
-    },
-
-    /**
-     * Determine if the image is in a draggable state
-     *
-     * When the image can be dragged, the drag event is acted upon and cancelled.
-     * When not draggable, the drag event bubbles through this component.
-     *
-     * @return {Boolean}
-     */
-    canDrag: function() {
-      return this.options.draggableUnzoomed || !isCloseTo(this.zoomFactor, 1);
-    },
-
-    /**
-     * Drags the element
-     * @param center
-     * @param lastCenter
-     */
-    drag: function(center, lastCenter) {
-      if (lastCenter) {
-        if (this.options.lockDragAxis) {
-          // lock scroll to position that was changed the most
-          if (
-            Math.abs(center.x - lastCenter.x) >
-            Math.abs(center.y - lastCenter.y)
-          ) {
-            this.addOffset({
-              x: -(center.x - lastCenter.x),
-              y: 0,
-            });
-          } else {
-            this.addOffset({
-              y: -(center.y - lastCenter.y),
-              x: 0,
-            });
-          }
+  /**
+   * Drags the element
+   * @param center
+   * @param lastCenter
+   */
+  public drag(center: Coordinates, lastCenter: Coordinates | null) {
+    if (lastCenter) {
+      if (this.options.lockDragAxis) {
+        // lock scroll to position that was changed the most
+        if (
+          Math.abs(center.x - lastCenter.x) > Math.abs(center.y - lastCenter.y)
+        ) {
+          this.addOffset({
+            x: -(center.x - lastCenter.x),
+            y: 0,
+          });
         } else {
           this.addOffset({
             y: -(center.y - lastCenter.y),
-            x: -(center.x - lastCenter.x),
+            x: 0,
           });
         }
-        if (typeof this.options.onDragUpdate == 'function') {
-          this.options.onDragUpdate(this, event);
-        }
-      }
-    },
-
-    /**
-     * Calculates the touch center of multiple touches
-     * @param touches
-     * @return {Object}
-     */
-    getTouchCenter: function(touches) {
-      return this.getVectorAvg(touches);
-    },
-
-    /**
-     * Calculates the average of multiple vectors (x, y values)
-     */
-    getVectorAvg: function(vectors) {
-      return {
-        x:
-          vectors
-            .map(function(v) {
-              return v.x;
-            })
-            .reduce(sum) / vectors.length,
-        y:
-          vectors
-            .map(function(v) {
-              return v.y;
-            })
-            .reduce(sum) / vectors.length,
-      };
-    },
-
-    /**
-     * Adds an offset
-     * @param offset the offset to add
-     * @return return true when the offset change was accepted
-     */
-    addOffset: function(offset) {
-      this.offset = {
-        x: this.offset.x + offset.x,
-        y: this.offset.y + offset.y,
-      };
-    },
-
-    sanitize: function() {
-      if (this.zoomFactor < this.options.zoomOutFactor) {
-        this.zoomOutAnimation();
-      } else if (this.isInsaneOffset(this.offset)) {
-        this.sanitizeOffsetAnimation();
-      }
-    },
-
-    /**
-     * Checks if the offset is ok with the current zoom factor
-     * @param offset
-     * @return {Boolean}
-     */
-    isInsaneOffset: function(offset) {
-      const sanitizedOffset = this.sanitizeOffset(offset);
-      return sanitizedOffset.x !== offset.x || sanitizedOffset.y !== offset.y;
-    },
-
-    /**
-     * Creates an animation moving to a sane offset
-     */
-    sanitizeOffsetAnimation: function() {
-      const targetOffset = this.sanitizeOffset(this.offset),
-        startOffset = {
-          x: this.offset.x,
-          y: this.offset.y,
-        },
-        updateProgress = function(progress) {
-          this.offset.x =
-            startOffset.x + progress * (targetOffset.x - startOffset.x);
-          this.offset.y =
-            startOffset.y + progress * (targetOffset.y - startOffset.y);
-          this.update();
-        }.bind(this);
-
-      this.animate(this.options.animationDuration, updateProgress, this.swing);
-    },
-
-    /**
-     * Zooms back to the original position,
-     * (no offset and zoom factor 1)
-     */
-    zoomOutAnimation: function() {
-      if (this.zoomFactor === 1) {
-        return;
-      }
-
-      const startZoomFactor = this.zoomFactor,
-        zoomFactor = 1,
-        center = this.getCurrentZoomCenter(),
-        updateProgress = function(progress) {
-          this.scaleTo(
-            startZoomFactor + progress * (zoomFactor - startZoomFactor),
-            center
-          );
-        }.bind(this);
-
-      this.animate(this.options.animationDuration, updateProgress, this.swing);
-    },
-
-    /**
-     * Updates the container aspect ratio
-     *
-     * Any previous container height must be cleared before re-measuring the
-     * parent height, since it depends implicitly on the height of any of its children
-     */
-    updateAspectRatio: function() {
-      this.unsetContainerY();
-      this.setContainerY(this.container.parentElement.offsetHeight);
-    },
-
-    /**
-     * Calculates the initial zoom factor (for the element to fit into the container)
-     * @return {number} the initial zoom factor
-     */
-    getInitialZoomFactor: function() {
-      const xZoomFactor = this.container.offsetWidth / this.el.offsetWidth;
-      const yZoomFactor = this.container.offsetHeight / this.el.offsetHeight;
-
-      return Math.min(xZoomFactor, yZoomFactor);
-    },
-
-    /**
-     * Calculates the aspect ratio of the element
-     * @return the aspect ratio
-     */
-    getAspectRatio: function() {
-      return this.el.offsetWidth / this.el.offsetHeight;
-    },
-
-    /**
-     * Calculates the virtual zoom center for the current offset and zoom factor
-     * (used for reverse zoom)
-     * @return {Object} the current zoom center
-     */
-    getCurrentZoomCenter: function() {
-      const offsetLeft = this.offset.x - this.initialOffset.x;
-      const centerX =
-        -1 * this.offset.x - offsetLeft / (1 / this.zoomFactor - 1);
-
-      const offsetTop = this.offset.y - this.initialOffset.y;
-      const centerY =
-        -1 * this.offset.y - offsetTop / (1 / this.zoomFactor - 1);
-
-      return {
-        x: centerX,
-        y: centerY,
-      };
-    },
-
-    /**
-     * Returns the touches of an event relative to the container offset
-     * @param event
-     * @return array touches
-     */
-    getTouches: function(event) {
-      const rect = this.container.getBoundingClientRect();
-      const scrollTop =
-        document.documentElement.scrollTop || document.body.scrollTop;
-      const scrollLeft =
-        document.documentElement.scrollLeft || document.body.scrollLeft;
-      const posTop = rect.top + scrollTop;
-      const posLeft = rect.left + scrollLeft;
-
-      return Array.prototype.slice.call(event.touches).map(function(touch) {
-        return {
-          x: touch.pageX - posLeft,
-          y: touch.pageY - posTop,
-        };
-      });
-    },
-
-    /**
-     * Animation loop
-     * does not support simultaneous animations
-     * @param duration
-     * @param framefn
-     * @param timefn
-     * @param callback
-     */
-    animate: function(duration, framefn, timefn, callback) {
-      var startTime = Date.now(),
-        renderFrame = function() {
-          if (!this.inAnimation) {
-            return;
-          }
-          let frameTime = Date.now() - startTime,
-            progress = frameTime / duration;
-          if (frameTime >= duration) {
-            framefn(1);
-            if (callback) {
-              callback();
-            }
-            this.update();
-            this.stopAnimation();
-            this.update();
-          } else {
-            if (timefn) {
-              progress = timefn(progress);
-            }
-            framefn(progress);
-            this.update();
-            requestAnimationFrame(renderFrame);
-          }
-        }.bind(this);
-      this.inAnimation = true;
-      requestAnimationFrame(renderFrame);
-    },
-
-    /**
-     * Stops the animation
-     */
-    stopAnimation: function() {
-      this.inAnimation = false;
-    },
-
-    /**
-     * Swing timing function for animations
-     * @param p
-     * @return {Number}
-     */
-    swing: function(p) {
-      return -Math.cos(p * Math.PI) / 2 + 0.5;
-    },
-
-    getContainerX: function() {
-      return this.container.offsetWidth;
-    },
-
-    getContainerY: function() {
-      return this.container.offsetHeight;
-    },
-
-    setContainerY: function(y) {
-      return (this.container.style.height = y + 'px');
-    },
-
-    unsetContainerY: function() {
-      this.container.style.height = null;
-    },
-
-    /**
-     * Creates the expected html structure
-     */
-    setupMarkup: function() {
-      this.container = document.createElement('div');
-      this.container.classList.add('pinch-zoom-container');
-
-      this.el.parentNode.insertBefore(this.container, this.el);
-      this.container.appendChild(this.el);
-
-      this.container.style.overflow = 'hidden';
-      this.container.style.position = 'relative';
-
-      this.el.style.transformOrigin = '0% 0%';
-
-      this.el.style.position = 'absolute';
-    },
-
-    end: function() {
-      this.hasInteraction = false;
-      this.sanitize();
-      this.update();
-    },
-
-    /**
-     * Binds all required event listeners
-     */
-    bindEvents: function() {
-      const self = this;
-      detectGestures(this.container, this);
-
-      window.addEventListener('resize', this.update.bind(this));
-      Array.from(this.el.querySelectorAll('img')).forEach(function(imgEl) {
-        imgEl.addEventListener('load', self.update.bind(self));
-      });
-
-      if (this.el.nodeName === 'IMG') {
-        this.el.addEventListener('load', this.update.bind(this));
-      }
-    },
-
-    /**
-     * Updates the css values according to the current zoom factor and offset
-     */
-    update: function(event) {
-      if (event && event.type === 'resize') {
-        this.updateAspectRatio();
-        this.setupOffsets();
-      }
-
-      if (event && event.type === 'load') {
-        this.updateAspectRatio();
-        this.setupOffsets();
-      }
-
-      if (this.updatePlanned) {
-        return;
-      }
-      this.updatePlanned = true;
-
-      window.requestAnimationFrame(
-       () => {
-         this.updatePlanned = false;
-
-         const zoomFactor = this.getInitialZoomFactor() * this.zoomFactor,
-           offsetX = -this.offset.x / zoomFactor,
-           offsetY = -this.offset.y / zoomFactor;
-         this.el.style.transform = `scale(${zoomFactor}, ${zoomFactor}) translate(${offsetX}px, ${offsetY}px)`;
-       }
-      );
-    },
-
-    /**
-     * Enables event handling for gestures
-     */
-    enable: function() {
-      this.enabled = true;
-    },
-
-    /**
-     * Disables event handling for gestures
-     */
-    disable: function() {
-      this.enabled = false;
-    },
-  };
-
-  var detectGestures = function(el, target) {
-    let interaction = null,
-      fingers = 0,
-      lastTouchStart = null,
-      startTouches = null,
-      setInteraction = function(newInteraction, event) {
-        if (interaction !== newInteraction) {
-          if (interaction && !newInteraction) {
-            switch (interaction) {
-              case 'zoom':
-                target.handleZoomEnd(event);
-                break;
-              case 'drag':
-                target.handleDragEnd(event);
-                break;
-            }
-          }
-
-          switch (newInteraction) {
-            case 'zoom':
-              target.handleZoomStart(event);
-              break;
-            case 'drag':
-              target.handleDragStart(event);
-              break;
-          }
-        }
-        interaction = newInteraction;
-      },
-      updateInteraction = function(event) {
-        if (fingers === 2) {
-          setInteraction('zoom');
-        } else if (fingers === 1 && target.canDrag()) {
-          setInteraction('drag', event);
-        } else {
-          setInteraction(null, event);
-        }
-      },
-      targetTouches = function(touches) {
-        return Array.from(touches).map(function(touch) {
-          return {
-            x: touch.pageX,
-            y: touch.pageY,
-          };
+      } else {
+        this.addOffset({
+          y: -(center.y - lastCenter.y),
+          x: -(center.x - lastCenter.x),
         });
-      },
-      getDistance = function(a, b) {
-        let x, y;
-        x = a.x - b.x;
-        y = a.y - b.y;
-        return Math.sqrt(x * x + y * y);
-      },
-      calculateScale = function(startTouches, endTouches) {
-        const startDistance = getDistance(startTouches[0], startTouches[1]),
-          endDistance = getDistance(endTouches[0], endTouches[1]);
-        return endDistance / startDistance;
-      },
-      cancelEvent = function(event) {
-        event.stopPropagation();
-        event.preventDefault();
-      },
-      detectDoubleTap = function(event) {
-        const time = new Date().getTime();
+      }
+      if (typeof this.options.onDragUpdate == 'function') {
+        this.options.onDragUpdate(this, event);
+      }
+    }
+  }
 
-        if (fingers > 1) {
-          lastTouchStart = null;
+  /**
+   * Calculates the touch center of multiple touches
+   * @param touches
+   * @return {Object}
+   */
+  public getTouchCenter(touches: Coordinates[]) {
+    return this.getVectorAvg(touches);
+  }
+
+  /**
+   * Calculates the average of multiple vectors (x, y values)
+   */
+  public getVectorAvg(vectors: Coordinates[]) {
+    const sum = (a: number, b: number) => {
+      return a + b;
+    };
+    return {
+      x: vectors.map(v => v.x).reduce(sum) / vectors.length,
+      y: vectors.map(v => v.y).reduce(sum) / vectors.length,
+    };
+  }
+
+  /**
+   * Adds an offset
+   * @param offset the offset to add
+   * @return return true when the offset change was accepted
+   */
+  public addOffset(offset: Coordinates) {
+    this.offset = {
+      x: this.offset.x + offset.x,
+      y: this.offset.y + offset.y,
+    };
+  }
+
+  public sanitize() {
+    if (this.zoomFactor < this.options.zoomOutFactor) {
+      this.zoomOutAnimation();
+    } else if (this.isInsaneOffset(this.offset)) {
+      this.sanitizeOffsetAnimation();
+    }
+  }
+
+  /**
+   * Checks if the offset is ok with the current zoom factor
+   * @param offset
+   * @return {Boolean}
+   */
+  public isInsaneOffset(offset: Coordinates) {
+    const sanitizedOffset = this.sanitizeOffset(offset);
+    return sanitizedOffset.x !== offset.x || sanitizedOffset.y !== offset.y;
+  }
+
+  /**
+   * Creates an animation moving to a sane offset
+   */
+  public sanitizeOffsetAnimation() {
+    const targetOffset = this.sanitizeOffset(this.offset);
+    const startOffset = {
+      x: this.offset.x,
+      y: this.offset.y,
+    };
+    const updateProgress = (progress: number) => {
+      this.offset.x =
+        startOffset.x + progress * (targetOffset.x - startOffset.x);
+      this.offset.y =
+        startOffset.y + progress * (targetOffset.y - startOffset.y);
+      this.update();
+    };
+
+    this.animate(
+      this.options.animationDuration,
+      updateProgress.bind(this),
+      this.swing
+    );
+  }
+
+  /**
+   * Zooms back to the original position,
+   * (no offset and zoom factor 1)
+   */
+  public zoomOutAnimation() {
+    if (this.zoomFactor === 1) {
+      return;
+    }
+
+    const startZoomFactor = this.zoomFactor;
+    const zoomFactor = 1;
+    const center = this.getCurrentZoomCenter();
+    const updateProgress = (progress: number) => {
+      this.scaleTo(
+        startZoomFactor + progress * (zoomFactor - startZoomFactor),
+        center
+      );
+    };
+
+    this.animate(
+      this.options.animationDuration,
+      updateProgress.bind(this),
+      this.swing
+    );
+  }
+
+  /**
+   * Updates the container aspect ratio
+   *
+   * Any previous container height must be cleared before re-measuring the
+   * parent height, since it depends implicitly on the height of any of its children
+   */
+  public updateAspectRatio() {
+    this.unsetContainerY();
+    if (this.container.parentElement) {
+      this.setContainerY(this.container.parentElement.offsetHeight);
+    }
+  }
+
+  /**
+   * Calculates the initial zoom factor (for the element to fit into the container)
+   * @return {number} the initial zoom factor
+   */
+  public getInitialZoomFactor() {
+    const xZoomFactor = this.container.offsetWidth / this.el.offsetWidth;
+    const yZoomFactor = this.container.offsetHeight / this.el.offsetHeight;
+
+    return Math.min(xZoomFactor, yZoomFactor);
+  }
+
+  /**
+   * Calculates the aspect ratio of the element
+   * @return the aspect ratio
+   */
+  public getAspectRatio() {
+    return this.el.offsetWidth / this.el.offsetHeight;
+  }
+
+  /**
+   * Calculates the virtual zoom center for the current offset and zoom factor
+   * (used for reverse zoom)
+   * @return {Object} the current zoom center
+   */
+  public getCurrentZoomCenter() {
+    const offsetLeft = this.offset.x - this.initialOffset.x;
+    const centerX = -1 * this.offset.x - offsetLeft / (1 / this.zoomFactor - 1);
+
+    const offsetTop = this.offset.y - this.initialOffset.y;
+    const centerY = -1 * this.offset.y - offsetTop / (1 / this.zoomFactor - 1);
+
+    return {
+      x: centerX,
+      y: centerY,
+    };
+  }
+
+  /**
+   * Returns the touches of an event relative to the container offset
+   * @param event
+   * @return array touches
+   */
+  public getTouches(event: TouchEvent): Coordinates[] {
+    const rect = this.container.getBoundingClientRect();
+    const scrollTop =
+      document.documentElement.scrollTop || document.body.scrollTop;
+    const scrollLeft =
+      document.documentElement.scrollLeft || document.body.scrollLeft;
+    const posTop = rect.top + scrollTop;
+    const posLeft = rect.left + scrollLeft;
+
+    return Array.prototype.map.call(event.touches, touch => {
+      return {
+        x: touch.pageX - posLeft,
+        y: touch.pageY - posTop,
+      };
+    }) as Coordinates[];
+  }
+
+  /**
+   * Animation loop
+   * does not support simultaneous animations
+   * @param duration
+   * @param framefn
+   * @param timefn
+   * @param callback
+   */
+  public animate(
+    duration: number,
+    framefn: (progress: number) => unknown,
+    timefn: (progress: number) => number,
+    callback?: () => unknown
+  ) {
+    const startTime = Date.now();
+    const renderFrame = () => {
+      if (!this.inAnimation) {
+        return;
+      }
+      const frameTime = Date.now() - startTime;
+      let progress: number = frameTime / duration;
+      if (frameTime >= duration) {
+        framefn(1);
+        if (callback) {
+          callback();
         }
+        this.update();
+        this.stopAnimation();
+        this.update();
+      } else {
+        if (timefn) {
+          progress = timefn(progress);
+        }
+        framefn(progress);
+        this.update();
+        requestAnimationFrame(renderFrame);
+      }
+    };
+    this.inAnimation = true;
+    requestAnimationFrame(renderFrame);
+  }
 
-        if (time - lastTouchStart < 300) {
-          cancelEvent(event);
+  /**
+   * Stops the animation
+   */
+  public stopAnimation() {
+    this.inAnimation = false;
+  }
 
-          target.handleDoubleTap(event);
+  /**
+   * Swing timing function for animations
+   * @param p
+   * @return {Number}
+   */
+  public swing(p: number) {
+    return -Math.cos(p * Math.PI) / 2 + 0.5;
+  }
+
+  public getContainerX() {
+    return this.container.offsetWidth;
+  }
+
+  public getContainerY() {
+    return this.container.offsetHeight;
+  }
+
+  public setContainerY(y: number) {
+    return (this.container.style.height = y + 'px');
+  }
+
+  public unsetContainerY() {
+    this.container.style.removeProperty('height');
+  }
+
+  /**
+   * Creates the expected html structure
+   */
+  public setupMarkup() {
+    this.container.classList.add('pinch-zoom-container');
+
+    if (this.el.parentNode) {
+      this.el.parentNode.insertBefore(this.container, this.el);
+    }
+    this.container.appendChild(this.el);
+
+    this.container.style.overflow = 'hidden';
+    this.container.style.position = 'relative';
+
+    this.el.style.transformOrigin = '0% 0%';
+
+    this.el.style.position = 'absolute';
+  }
+
+  public end() {
+    this.hasInteraction = false;
+    this.sanitize();
+    this.update();
+  }
+
+  /**
+   * Binds all required event listeners
+   */
+  public bindEvents() {
+    this.detectGestures();
+
+    window.addEventListener('resize', this.update.bind(this));
+    Array.from(this.el.querySelectorAll('img')).forEach(imgEl => {
+      imgEl.addEventListener('load', this.update.bind(this));
+    });
+
+    if (this.el.nodeName === 'IMG') {
+      this.el.addEventListener('load', this.update.bind(this));
+    }
+  }
+
+  /**
+   * Updates the css values according to the current zoom factor and offset
+   */
+  public update(event?: Event) {
+    if (event && event.type === 'resize') {
+      this.updateAspectRatio();
+      this.setupOffsets();
+    }
+
+    if (event && event.type === 'load') {
+      this.updateAspectRatio();
+      this.setupOffsets();
+    }
+
+    if (this.updatePlanned) {
+      return;
+    }
+    this.updatePlanned = true;
+
+    window.requestAnimationFrame(() => {
+      this.updatePlanned = false;
+
+      const zoomFactor = this.getInitialZoomFactor() * this.zoomFactor,
+        offsetX = -this.offset.x / zoomFactor,
+        offsetY = -this.offset.y / zoomFactor;
+      this.el.style.transform = `scale(${zoomFactor}, ${zoomFactor}) translate(${offsetX}px, ${offsetY}px)`;
+    });
+  }
+
+  /**
+   * Enables event handling for gestures
+   */
+  public enable() {
+    this.enabled = true;
+  }
+
+  /**
+   * Disables event handling for gestures
+   */
+  public disable() {
+    this.enabled = false;
+  }
+
+  private detectGestures() {
+    let interaction: string | null = null;
+    let fingers = 0;
+    let lastTouchStart: number = 0;
+    let startTouches: Coordinates[] | null = null;
+    const setInteraction = (
+      newInteraction: string | null,
+      event: TouchEvent
+    ) => {
+      if (interaction !== newInteraction) {
+        if (interaction && !newInteraction) {
           switch (interaction) {
             case 'zoom':
-              target.handleZoomEnd(event);
+              this.handleZoomEnd(event);
               break;
             case 'drag':
-              target.handleDragEnd(event);
+              this.handleDragEnd(event);
               break;
           }
-        } else {
-          target.isDoubleTap = false;
         }
 
-        if (fingers === 1) {
-          lastTouchStart = time;
+        switch (newInteraction) {
+          case 'zoom':
+            this.handleZoomStart(event);
+            break;
+          case 'drag':
+            this.handleDragStart(event);
+            break;
         }
-      },
-      firstMove = true;
+      }
+      interaction = newInteraction;
+    };
+    const updateInteraction = (event: TouchEvent) => {
+      if (fingers === 2) {
+        setInteraction('zoom', event);
+      } else if (fingers === 1 && this.canDrag()) {
+        setInteraction('drag', event);
+      } else {
+        setInteraction(null, event);
+      }
+    };
+    const targetTouches = (touches: TouchList): Coordinates[] => {
+      return Array.prototype.map.call(touches, touch => {
+        return {
+          x: touch.pageX,
+          y: touch.pageY,
+        };
+      }) as Coordinates[];
+    };
+    const getDistance = (a: Coordinates, b: Coordinates) => {
+      const x = a.x - b.x;
+      const y = a.y - b.y;
+      return Math.sqrt(x * x + y * y);
+    };
+    const calculateScale = (
+      startTouches: Coordinates[],
+      endTouches: Coordinates[]
+    ) => {
+      const startDistance = getDistance(startTouches[0], startTouches[1]);
+      const endDistance = getDistance(endTouches[0], endTouches[1]);
+      return endDistance / startDistance;
+    };
+    const cancelEvent = (event: TouchEvent) => {
+      event.stopPropagation();
+      event.preventDefault();
+    };
+    const detectDoubleTap = (event: TouchEvent) => {
+      const time = Date.now();
 
-    el.addEventListener(
-      'touchstart',
-      function(event) {
-        if (target.enabled) {
-          firstMove = true;
-          fingers = event.touches.length;
-          detectDoubleTap(event);
+      if (fingers > 1) {
+        lastTouchStart = 0;
+      }
+
+      if (time - lastTouchStart < 300) {
+        cancelEvent(event);
+
+        this.handleDoubleTap(event);
+        switch (interaction) {
+          case 'zoom':
+            this.handleZoomEnd(event);
+            break;
+          case 'drag':
+            this.handleDragEnd(event);
+            break;
         }
-      },
-      { passive: false }
-    );
+      } else {
+        this.isDoubleTap = false;
+      }
 
-    el.addEventListener(
-      'touchmove',
-      function(event) {
-        if (target.enabled && !target.isDoubleTap) {
-          if (firstMove) {
-            updateInteraction(event);
-            if (interaction) {
-              cancelEvent(event);
-            }
-            startTouches = targetTouches(event.touches);
-          } else {
-            switch (interaction) {
-              case 'zoom':
-                if (startTouches.length == 2 && event.touches.length == 2) {
-                  target.handleZoom(
-                    event,
-                    calculateScale(startTouches, targetTouches(event.touches))
-                  );
-                }
-                break;
-              case 'drag':
-                target.handleDrag(event);
-                break;
-            }
-            if (interaction) {
-              cancelEvent(event);
-              target.update();
-            }
+      if (fingers === 1) {
+        lastTouchStart = time;
+      }
+    };
+    let firstMove = true;
+
+    const handleTouchStart = (event: TouchEvent) => {
+      if (this.enabled) {
+        firstMove = true;
+        fingers = event.touches.length;
+        detectDoubleTap(event);
+      }
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      if (this.enabled && !this.isDoubleTap) {
+        if (firstMove) {
+          updateInteraction(event);
+          if (interaction) {
+            cancelEvent(event);
           }
-
-          firstMove = false;
+          startTouches = targetTouches(event.touches);
+        } else {
+          switch (interaction) {
+            case 'zoom':
+              if (
+                startTouches &&
+                startTouches.length == 2 &&
+                event.touches.length == 2
+              ) {
+                this.handleZoom(
+                  event,
+                  calculateScale(startTouches, targetTouches(event.touches))
+                );
+              }
+              break;
+            case 'drag':
+              this.handleDrag(event);
+              break;
+          }
+          if (interaction) {
+            cancelEvent(event);
+            this.update();
+          }
         }
-      },
-      { passive: false }
-    );
 
-    el.addEventListener('touchend', function(event) {
-      if (target.enabled) {
+        firstMove = false;
+      }
+    };
+    const handleTouchEnd = (event: TouchEvent) => {
+      if (this.enabled) {
         fingers = event.touches.length;
         updateInteraction(event);
       }
+    };
+
+    this.container.addEventListener('touchstart', handleTouchStart.bind(this), {
+      passive: false,
     });
-  };
 
-  return PinchZoom;
-};
+    this.container.addEventListener('touchmove', handleTouchMove.bind(this), {
+      passive: false,
+    });
 
-const PinchZoom = definePinchZoom();
-
-export default PinchZoom;
+    this.container.addEventListener('touchend', handleTouchEnd.bind(this));
+  }
+}

--- a/src/components/SVGViewer/pinchzoom.ts
+++ b/src/components/SVGViewer/pinchzoom.ts
@@ -1,0 +1,887 @@
+// Copyright 2020 Cognite AS
+
+// @ts-nocheck
+/* eslint-disable */
+if (typeof Object.assign != 'function') {
+  // Must be writable: true, enumerable: false, configurable: true
+  Object.defineProperty(Object, 'assign', {
+    value: function assign(target, varArgs) {
+      // .length of function is 2
+      if (target == null) {
+        // TypeError if undefined or null
+        throw new TypeError('Cannot convert undefined or null to object');
+      }
+
+      const to = Object(target);
+
+      for (let index = 1; index < arguments.length; index++) {
+        const nextSource = arguments[index];
+
+        if (nextSource != null) {
+          // Skip over if undefined or null
+          for (const nextKey in nextSource) {
+            // Avoid bugs when hasOwnProperty is shadowed
+            if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+              to[nextKey] = nextSource[nextKey];
+            }
+          }
+        }
+      }
+      return to;
+    },
+    writable: true,
+    configurable: true,
+  });
+}
+
+if (typeof Array.from != 'function') {
+  Array.from = function(object) {
+    return [].slice.call(object);
+  };
+}
+
+// utils
+const buildElement = function(str) {
+  // empty string as title argument required by IE and Edge
+  const tmp = document.implementation.createHTMLDocument('');
+  tmp.body.innerHTML = str;
+  return Array.from(tmp.body.children)[0];
+};
+
+const definePinchZoom = function() {
+  /**
+   * Pinch zoom
+   * @param el
+   * @param options
+   * @constructor
+   */
+  const PinchZoom = function(el, options) {
+      this.el = el;
+      this.zoomFactor = 1;
+      this.lastScale = 1;
+      this.offset = {
+        x: 0,
+        y: 0,
+      };
+      this.initialOffset = {
+        x: 0,
+        y: 0,
+      };
+      this.options = Object.assign({}, this.defaults, options);
+      this.setupMarkup();
+      this.bindEvents();
+      this.update();
+
+      // The image may already be loaded when PinchZoom is initialized,
+      // and then the load event (which trigger update) will never fire.
+      if (this.isImageLoaded(this.el)) {
+        this.updateAspectRatio();
+        this.setupOffsets();
+      }
+
+      this.enable();
+    },
+    sum = function(a, b) {
+      return a + b;
+    },
+    isCloseTo = function(value, expected) {
+      return value > expected - 0.01 && value < expected + 0.01;
+    };
+
+  PinchZoom.prototype = {
+    defaults: {
+      tapZoomFactor: 2,
+      zoomOutFactor: 1.3,
+      animationDuration: 300,
+      maxZoom: 4,
+      minZoom: 0.5,
+      draggableUnzoomed: true,
+      lockDragAxis: false,
+      setOffsetsOnce: false,
+      use2d: true,
+      verticalPadding: 0,
+      horizontalPadding: 0,
+      onZoomStart: null,
+      onZoomEnd: null,
+      onZoomUpdate: null,
+      onDragStart: null,
+      onDragEnd: null,
+      onDragUpdate: null,
+      onDoubleTap: null,
+    },
+
+    /**
+     * Event handler for 'dragstart'
+     * @param event
+     */
+    handleDragStart: function(event) {
+      if (typeof this.options.onDragStart == 'function') {
+        this.options.onDragStart(this, event);
+      }
+      this.stopAnimation();
+      this.lastDragPosition = false;
+      this.hasInteraction = true;
+      this.handleDrag(event);
+    },
+
+    /**
+     * Event handler for 'drag'
+     * @param event
+     */
+    handleDrag: function(event) {
+      const touch = this.getTouches(event)[0];
+      this.drag(touch, this.lastDragPosition);
+      this.offset = this.sanitizeOffset(this.offset);
+      this.lastDragPosition = touch;
+    },
+
+    handleDragEnd: function() {
+      if (typeof this.options.onDragEnd == 'function') {
+        this.options.onDragEnd(this, event);
+      }
+      this.end();
+    },
+
+    /**
+     * Event handler for 'zoomstart'
+     * @param event
+     */
+    handleZoomStart: function(event) {
+      if (typeof this.options.onZoomStart == 'function') {
+        this.options.onZoomStart(this, event);
+      }
+      this.stopAnimation();
+      this.lastScale = 1;
+      this.nthZoom = 0;
+      this.lastZoomCenter = false;
+      this.hasInteraction = true;
+    },
+
+    /**
+     * Event handler for 'zoom'
+     * @param event
+     */
+    handleZoom: function(event, newScale) {
+      // a relative scale factor is used
+      const touchCenter = this.getTouchCenter(this.getTouches(event)),
+        scale = newScale / this.lastScale;
+      this.lastScale = newScale;
+
+      // the first touch events are thrown away since they are not precise
+      this.nthZoom += 1;
+      if (this.nthZoom > 3) {
+        this.scale(scale, touchCenter);
+        this.drag(touchCenter, this.lastZoomCenter);
+      }
+      this.lastZoomCenter = touchCenter;
+    },
+
+    handleZoomEnd: function() {
+      if (typeof this.options.onZoomEnd == 'function') {
+        this.options.onZoomEnd(this, event);
+      }
+      this.end();
+    },
+
+    /**
+     * Event handler for 'doubletap'
+     * @param event
+     */
+    handleDoubleTap: function(event) {
+      let center = this.getTouches(event)[0],
+        zoomFactor = this.zoomFactor > 1 ? 1 : this.options.tapZoomFactor,
+        startZoomFactor = this.zoomFactor,
+        updateProgress = function(progress) {
+          this.scaleTo(
+            startZoomFactor + progress * (zoomFactor - startZoomFactor),
+            center
+          );
+        }.bind(this);
+
+      if (this.hasInteraction) {
+        return;
+      }
+
+      this.isDoubleTap = true;
+
+      if (startZoomFactor > zoomFactor) {
+        center = this.getCurrentZoomCenter();
+      }
+
+      this.animate(this.options.animationDuration, updateProgress, this.swing);
+      if (typeof this.options.onDoubleTap == 'function') {
+        this.options.onDoubleTap(this, event);
+      }
+    },
+
+    /**
+     * Compute the initial offset
+     *
+     * the element should be centered in the container upon initialization
+     */
+    computeInitialOffset: function() {
+      this.initialOffset = {
+        x:
+          -Math.abs(
+            this.el.offsetWidth * this.getInitialZoomFactor() -
+              this.container.offsetWidth
+          ) / 2,
+        y:
+          -Math.abs(
+            this.el.offsetHeight * this.getInitialZoomFactor() -
+              this.container.offsetHeight
+          ) / 2,
+      };
+    },
+
+    /**
+     * Reset current image offset to that of the initial offset
+     */
+    resetOffset: function() {
+      this.offset.x = this.initialOffset.x;
+      this.offset.y = this.initialOffset.y;
+    },
+
+    /**
+     * Determine if image is loaded
+     */
+    isImageLoaded: function(el) {
+      if (el.nodeName === 'IMG') {
+        return el.complete && el.naturalHeight !== 0;
+      } else {
+        return Array.from(el.querySelectorAll('img')).every(this.isImageLoaded);
+      }
+    },
+
+    setupOffsets: function() {
+      if (this.options.setOffsetsOnce && this._isOffsetsSet) {
+        return;
+      }
+
+      this._isOffsetsSet = true;
+
+      this.computeInitialOffset();
+      this.resetOffset();
+    },
+
+    /**
+     * Max / min values for the offset
+     * @param offset
+     * @return {Object} the sanitized offset
+     */
+    sanitizeOffset: function(offset) {
+      const elWidth =
+        this.el.offsetWidth * this.getInitialZoomFactor() * this.zoomFactor;
+      const elHeight =
+        this.el.offsetHeight * this.getInitialZoomFactor() * this.zoomFactor;
+      const maxX =
+          elWidth - this.getContainerX() + this.options.horizontalPadding,
+        maxY = elHeight - this.getContainerY() + this.options.verticalPadding,
+        maxOffsetX = Math.max(maxX, 0),
+        maxOffsetY = Math.max(maxY, 0),
+        minOffsetX = Math.min(maxX, 0) - this.options.horizontalPadding,
+        minOffsetY = Math.min(maxY, 0) - this.options.verticalPadding;
+
+      return {
+        x: Math.min(Math.max(offset.x, minOffsetX), maxOffsetX),
+        y: Math.min(Math.max(offset.y, minOffsetY), maxOffsetY),
+      };
+    },
+
+    /**
+     * Scale to a specific zoom factor (not relative)
+     * @param zoomFactor
+     * @param center
+     */
+    scaleTo: function(zoomFactor, center) {
+      this.scale(zoomFactor / this.zoomFactor, center);
+    },
+
+    /**
+     * Scales the element from specified center
+     * @param scale
+     * @param center
+     */
+    scale: function(scale, center) {
+      scale = this.scaleZoomFactor(scale);
+      this.addOffset({
+        x: (scale - 1) * (center.x + this.offset.x),
+        y: (scale - 1) * (center.y + this.offset.y),
+      });
+      if (typeof this.options.onZoomUpdate == 'function') {
+        this.options.onZoomUpdate(this, event);
+      }
+    },
+
+    /**
+     * Scales the zoom factor relative to current state
+     * @param scale
+     * @return the actual scale (can differ because of max min zoom factor)
+     */
+    scaleZoomFactor: function(scale) {
+      const originalZoomFactor = this.zoomFactor;
+      this.zoomFactor *= scale;
+      this.zoomFactor = Math.min(
+        this.options.maxZoom,
+        Math.max(this.zoomFactor, this.options.minZoom)
+      );
+      return this.zoomFactor / originalZoomFactor;
+    },
+
+    /**
+     * Determine if the image is in a draggable state
+     *
+     * When the image can be dragged, the drag event is acted upon and cancelled.
+     * When not draggable, the drag event bubbles through this component.
+     *
+     * @return {Boolean}
+     */
+    canDrag: function() {
+      return this.options.draggableUnzoomed || !isCloseTo(this.zoomFactor, 1);
+    },
+
+    /**
+     * Drags the element
+     * @param center
+     * @param lastCenter
+     */
+    drag: function(center, lastCenter) {
+      if (lastCenter) {
+        if (this.options.lockDragAxis) {
+          // lock scroll to position that was changed the most
+          if (
+            Math.abs(center.x - lastCenter.x) >
+            Math.abs(center.y - lastCenter.y)
+          ) {
+            this.addOffset({
+              x: -(center.x - lastCenter.x),
+              y: 0,
+            });
+          } else {
+            this.addOffset({
+              y: -(center.y - lastCenter.y),
+              x: 0,
+            });
+          }
+        } else {
+          this.addOffset({
+            y: -(center.y - lastCenter.y),
+            x: -(center.x - lastCenter.x),
+          });
+        }
+        if (typeof this.options.onDragUpdate == 'function') {
+          this.options.onDragUpdate(this, event);
+        }
+      }
+    },
+
+    /**
+     * Calculates the touch center of multiple touches
+     * @param touches
+     * @return {Object}
+     */
+    getTouchCenter: function(touches) {
+      return this.getVectorAvg(touches);
+    },
+
+    /**
+     * Calculates the average of multiple vectors (x, y values)
+     */
+    getVectorAvg: function(vectors) {
+      return {
+        x:
+          vectors
+            .map(function(v) {
+              return v.x;
+            })
+            .reduce(sum) / vectors.length,
+        y:
+          vectors
+            .map(function(v) {
+              return v.y;
+            })
+            .reduce(sum) / vectors.length,
+      };
+    },
+
+    /**
+     * Adds an offset
+     * @param offset the offset to add
+     * @return return true when the offset change was accepted
+     */
+    addOffset: function(offset) {
+      this.offset = {
+        x: this.offset.x + offset.x,
+        y: this.offset.y + offset.y,
+      };
+    },
+
+    sanitize: function() {
+      if (this.zoomFactor < this.options.zoomOutFactor) {
+        this.zoomOutAnimation();
+      } else if (this.isInsaneOffset(this.offset)) {
+        this.sanitizeOffsetAnimation();
+      }
+    },
+
+    /**
+     * Checks if the offset is ok with the current zoom factor
+     * @param offset
+     * @return {Boolean}
+     */
+    isInsaneOffset: function(offset) {
+      const sanitizedOffset = this.sanitizeOffset(offset);
+      return sanitizedOffset.x !== offset.x || sanitizedOffset.y !== offset.y;
+    },
+
+    /**
+     * Creates an animation moving to a sane offset
+     */
+    sanitizeOffsetAnimation: function() {
+      const targetOffset = this.sanitizeOffset(this.offset),
+        startOffset = {
+          x: this.offset.x,
+          y: this.offset.y,
+        },
+        updateProgress = function(progress) {
+          this.offset.x =
+            startOffset.x + progress * (targetOffset.x - startOffset.x);
+          this.offset.y =
+            startOffset.y + progress * (targetOffset.y - startOffset.y);
+          this.update();
+        }.bind(this);
+
+      this.animate(this.options.animationDuration, updateProgress, this.swing);
+    },
+
+    /**
+     * Zooms back to the original position,
+     * (no offset and zoom factor 1)
+     */
+    zoomOutAnimation: function() {
+      if (this.zoomFactor === 1) {
+        return;
+      }
+
+      const startZoomFactor = this.zoomFactor,
+        zoomFactor = 1,
+        center = this.getCurrentZoomCenter(),
+        updateProgress = function(progress) {
+          this.scaleTo(
+            startZoomFactor + progress * (zoomFactor - startZoomFactor),
+            center
+          );
+        }.bind(this);
+
+      this.animate(this.options.animationDuration, updateProgress, this.swing);
+    },
+
+    /**
+     * Updates the container aspect ratio
+     *
+     * Any previous container height must be cleared before re-measuring the
+     * parent height, since it depends implicitly on the height of any of its children
+     */
+    updateAspectRatio: function() {
+      this.unsetContainerY();
+      this.setContainerY(this.container.parentElement.offsetHeight);
+    },
+
+    /**
+     * Calculates the initial zoom factor (for the element to fit into the container)
+     * @return {number} the initial zoom factor
+     */
+    getInitialZoomFactor: function() {
+      const xZoomFactor = this.container.offsetWidth / this.el.offsetWidth;
+      const yZoomFactor = this.container.offsetHeight / this.el.offsetHeight;
+
+      return Math.min(xZoomFactor, yZoomFactor);
+    },
+
+    /**
+     * Calculates the aspect ratio of the element
+     * @return the aspect ratio
+     */
+    getAspectRatio: function() {
+      return this.el.offsetWidth / this.el.offsetHeight;
+    },
+
+    /**
+     * Calculates the virtual zoom center for the current offset and zoom factor
+     * (used for reverse zoom)
+     * @return {Object} the current zoom center
+     */
+    getCurrentZoomCenter: function() {
+      const offsetLeft = this.offset.x - this.initialOffset.x;
+      const centerX =
+        -1 * this.offset.x - offsetLeft / (1 / this.zoomFactor - 1);
+
+      const offsetTop = this.offset.y - this.initialOffset.y;
+      const centerY =
+        -1 * this.offset.y - offsetTop / (1 / this.zoomFactor - 1);
+
+      return {
+        x: centerX,
+        y: centerY,
+      };
+    },
+
+    /**
+     * Returns the touches of an event relative to the container offset
+     * @param event
+     * @return array touches
+     */
+    getTouches: function(event) {
+      const rect = this.container.getBoundingClientRect();
+      const scrollTop =
+        document.documentElement.scrollTop || document.body.scrollTop;
+      const scrollLeft =
+        document.documentElement.scrollLeft || document.body.scrollLeft;
+      const posTop = rect.top + scrollTop;
+      const posLeft = rect.left + scrollLeft;
+
+      return Array.prototype.slice.call(event.touches).map(function(touch) {
+        return {
+          x: touch.pageX - posLeft,
+          y: touch.pageY - posTop,
+        };
+      });
+    },
+
+    /**
+     * Animation loop
+     * does not support simultaneous animations
+     * @param duration
+     * @param framefn
+     * @param timefn
+     * @param callback
+     */
+    animate: function(duration, framefn, timefn, callback) {
+      var startTime = new Date().getTime(),
+        renderFrame = function() {
+          if (!this.inAnimation) {
+            return;
+          }
+          let frameTime = new Date().getTime() - startTime,
+            progress = frameTime / duration;
+          if (frameTime >= duration) {
+            framefn(1);
+            if (callback) {
+              callback();
+            }
+            this.update();
+            this.stopAnimation();
+            this.update();
+          } else {
+            if (timefn) {
+              progress = timefn(progress);
+            }
+            framefn(progress);
+            this.update();
+            requestAnimationFrame(renderFrame);
+          }
+        }.bind(this);
+      this.inAnimation = true;
+      requestAnimationFrame(renderFrame);
+    },
+
+    /**
+     * Stops the animation
+     */
+    stopAnimation: function() {
+      this.inAnimation = false;
+    },
+
+    /**
+     * Swing timing function for animations
+     * @param p
+     * @return {Number}
+     */
+    swing: function(p) {
+      return -Math.cos(p * Math.PI) / 2 + 0.5;
+    },
+
+    getContainerX: function() {
+      return this.container.offsetWidth;
+    },
+
+    getContainerY: function() {
+      return this.container.offsetHeight;
+    },
+
+    setContainerY: function(y) {
+      return (this.container.style.height = y + 'px');
+    },
+
+    unsetContainerY: function() {
+      this.container.style.height = null;
+    },
+
+    /**
+     * Creates the expected html structure
+     */
+    setupMarkup: function() {
+      this.container = buildElement('<div class="pinch-zoom-container"></div>');
+      this.el.parentNode.insertBefore(this.container, this.el);
+      this.container.appendChild(this.el);
+
+      this.container.style.overflow = 'hidden';
+      this.container.style.position = 'relative';
+
+      this.el.style.webkitTransformOrigin = '0% 0%';
+      this.el.style.mozTransformOrigin = '0% 0%';
+      this.el.style.msTransformOrigin = '0% 0%';
+      this.el.style.oTransformOrigin = '0% 0%';
+      this.el.style.transformOrigin = '0% 0%';
+
+      this.el.style.position = 'absolute';
+    },
+
+    end: function() {
+      this.hasInteraction = false;
+      this.sanitize();
+      this.update();
+    },
+
+    /**
+     * Binds all required event listeners
+     */
+    bindEvents: function() {
+      const self = this;
+      detectGestures(this.container, this);
+
+      window.addEventListener('resize', this.update.bind(this));
+      Array.from(this.el.querySelectorAll('img')).forEach(function(imgEl) {
+        imgEl.addEventListener('load', self.update.bind(self));
+      });
+
+      if (this.el.nodeName === 'IMG') {
+        this.el.addEventListener('load', this.update.bind(this));
+      }
+    },
+
+    /**
+     * Updates the css values according to the current zoom factor and offset
+     */
+    update: function(event) {
+      if (event && event.type === 'resize') {
+        this.updateAspectRatio();
+        this.setupOffsets();
+      }
+
+      if (event && event.type === 'load') {
+        this.updateAspectRatio();
+        this.setupOffsets();
+      }
+
+      if (this.updatePlanned) {
+        return;
+      }
+      this.updatePlanned = true;
+
+      window.requestAnimationFrame(
+       () => {
+         this.updatePlanned = false;
+
+         const zoomFactor = this.getInitialZoomFactor() * this.zoomFactor,
+           offsetX = -this.offset.x / zoomFactor,
+           offsetY = -this.offset.y / zoomFactor,
+           transform3d =
+             'scale3d(' +
+             zoomFactor +
+             ', ' +
+             zoomFactor +
+             ',1) ' +
+             'translate3d(' +
+             offsetX +
+             'px,' +
+             offsetY +
+             'px,0px)',
+           transform2d =
+             'scale(' +
+             zoomFactor +
+             ', ' +
+             zoomFactor +
+             ') ' +
+             'translate(' +
+             offsetX +
+             'px,' +
+             offsetY +
+             'px)';
+
+         this.el.style.webkitTransform = transform3d;
+         this.el.style.mozTransform = transform2d;
+         this.el.style.msTransform = transform2d;
+         this.el.style.oTransform = transform2d;
+         this.el.style.transform = transform3d;
+       }
+      );
+    },
+
+    /**
+     * Enables event handling for gestures
+     */
+    enable: function() {
+      this.enabled = true;
+    },
+
+    /**
+     * Disables event handling for gestures
+     */
+    disable: function() {
+      this.enabled = false;
+    },
+  };
+
+  var detectGestures = function(el, target) {
+    let interaction = null,
+      fingers = 0,
+      lastTouchStart = null,
+      startTouches = null,
+      setInteraction = function(newInteraction, event) {
+        if (interaction !== newInteraction) {
+          if (interaction && !newInteraction) {
+            switch (interaction) {
+              case 'zoom':
+                target.handleZoomEnd(event);
+                break;
+              case 'drag':
+                target.handleDragEnd(event);
+                break;
+            }
+          }
+
+          switch (newInteraction) {
+            case 'zoom':
+              target.handleZoomStart(event);
+              break;
+            case 'drag':
+              target.handleDragStart(event);
+              break;
+          }
+        }
+        interaction = newInteraction;
+      },
+      updateInteraction = function(event) {
+        if (fingers === 2) {
+          setInteraction('zoom');
+        } else if (fingers === 1 && target.canDrag()) {
+          setInteraction('drag', event);
+        } else {
+          setInteraction(null, event);
+        }
+      },
+      targetTouches = function(touches) {
+        return Array.from(touches).map(function(touch) {
+          return {
+            x: touch.pageX,
+            y: touch.pageY,
+          };
+        });
+      },
+      getDistance = function(a, b) {
+        let x, y;
+        x = a.x - b.x;
+        y = a.y - b.y;
+        return Math.sqrt(x * x + y * y);
+      },
+      calculateScale = function(startTouches, endTouches) {
+        const startDistance = getDistance(startTouches[0], startTouches[1]),
+          endDistance = getDistance(endTouches[0], endTouches[1]);
+        return endDistance / startDistance;
+      },
+      cancelEvent = function(event) {
+        event.stopPropagation();
+        event.preventDefault();
+      },
+      detectDoubleTap = function(event) {
+        const time = new Date().getTime();
+
+        if (fingers > 1) {
+          lastTouchStart = null;
+        }
+
+        if (time - lastTouchStart < 300) {
+          cancelEvent(event);
+
+          target.handleDoubleTap(event);
+          switch (interaction) {
+            case 'zoom':
+              target.handleZoomEnd(event);
+              break;
+            case 'drag':
+              target.handleDragEnd(event);
+              break;
+          }
+        } else {
+          target.isDoubleTap = false;
+        }
+
+        if (fingers === 1) {
+          lastTouchStart = time;
+        }
+      },
+      firstMove = true;
+
+    el.addEventListener(
+      'touchstart',
+      function(event) {
+        if (target.enabled) {
+          firstMove = true;
+          fingers = event.touches.length;
+          detectDoubleTap(event);
+        }
+      },
+      { passive: false }
+    );
+
+    el.addEventListener(
+      'touchmove',
+      function(event) {
+        if (target.enabled && !target.isDoubleTap) {
+          if (firstMove) {
+            updateInteraction(event);
+            if (interaction) {
+              cancelEvent(event);
+            }
+            startTouches = targetTouches(event.touches);
+          } else {
+            switch (interaction) {
+              case 'zoom':
+                if (startTouches.length == 2 && event.touches.length == 2) {
+                  target.handleZoom(
+                    event,
+                    calculateScale(startTouches, targetTouches(event.touches))
+                  );
+                }
+                break;
+              case 'drag':
+                target.handleDrag(event);
+                break;
+            }
+            if (interaction) {
+              cancelEvent(event);
+              target.update();
+            }
+          }
+
+          firstMove = false;
+        }
+      },
+      { passive: false }
+    );
+
+    el.addEventListener('touchend', function(event) {
+      if (target.enabled) {
+        fingers = event.touches.length;
+        updateInteraction(event);
+      }
+    });
+  };
+
+  return PinchZoom;
+};
+
+const PinchZoom = definePinchZoom();
+
+export default PinchZoom;

--- a/yarn.lock
+++ b/yarn.lock
@@ -12325,11 +12325,6 @@ pify@^4.0.1:
   resolved "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
   integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
-pinch-zoom-js@^2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/pinch-zoom-js/-/pinch-zoom-js-2.3.4.tgz#b1019eb2af88b33a546cc7b67eaeb11f8a209e8c"
-  integrity sha512-w6aw3vsXtDEH0RZPtiSKFihhqKPbLvqtT7HvMOeZVDPqQ5M1RLfrF83dfpr8WdWUEyQSlH+8pTIsNskZwjorag==
-
 pinkie-promise@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/pinkie-promise/-/pinkie-promise-2.0.1.tgz#2135d6dfa7a358c069ac9b178776288228450ffa"


### PR DESCRIPTION
Still very far away from being perfect, but Chrome's profiler shows that it's better than before (recorded on iSafe). 

### Before

![image](https://user-images.githubusercontent.com/4989157/146406323-ad97ccb8-6dbb-4122-8337-1807f42b9244.png)

### After

![image](https://user-images.githubusercontent.com/4989157/146406477-48780f7b-4f66-418f-8454-c416e40bad87.png)

Even from images, you can see that there are fewer long-running tasks and red labels now.

In case if you want to take a look locally, there are profiles recorded for isafe (original and after optimizations).

[Profiles.zip](https://github.com/cognitedata/gearbox.js/files/7728722/Profiles.zip)

### Optimisations

* I made pinch-to-zoom to be a local file instead of 3rd party dependency to make it easier to modify. I removed some code that is simply not needed for us and also removed the part that did cloning and re-inserting of the whole SVG node on every interaction. So that's the biggest optimization I believe. I'm not sure why they needed it in the first place, but guess they have some reasons. The library even supports IE.
* Rewrote logic for overriding CTRL+F behavior. Before, on every interaction, there was a call to .focus on hidden input which is not so performant. Doesn't happen anymore. I simply made container div to handle focus/blur by adding tabindex and listening for keydowns on it. 
* There was an attempt to use will-change property in SVG viewer but it didn't really work. Works now. It is supposed to enable some magic browser optimizations but also it has a visible effect - SVG is less blurry now when SVG viewer has focus. But performance-wise it's hard to tell if it makes any difference.


Don't set high expectations about it, it's still pretty laggy for big SVGs, but a tiny bit better than before.